### PR TITLE
LCAM-516

### DIFF
--- a/crime-commons-spring-boot-starter-rest-client/src/main/java/uk/gov/justice/laa/crime/commons/config/RestClientAutoConfiguration.java
+++ b/crime-commons-spring-boot-starter-rest-client/src/main/java/uk/gov/justice/laa/crime/commons/config/RestClientAutoConfiguration.java
@@ -151,4 +151,10 @@ public class RestClientAutoConfiguration {
         return new RestAPIClient(webClient, "maat-api");
     }
 
+    @Bean
+    @ConditionalOnProperty(name = "spring.security.oauth2.client.provider.evidence.token-uri")
+    RestAPIClient evidenceApiClient(WebClient webClient) {
+        return new RestAPIClient(webClient, "evidence");
+    }
+
 }

--- a/crime-commons-spring-boot-starter-rest-client/src/test/java/uk/gov/justice/laa/crime/commons/config/RestClientAutoConfigurationTest.java
+++ b/crime-commons-spring-boot-starter-rest-client/src/test/java/uk/gov/justice/laa/crime/commons/config/RestClientAutoConfigurationTest.java
@@ -30,8 +30,10 @@ class RestClientAutoConfigurationTest {
 
     private static final String CDA_REGISTRATION_ID = "cda";
     private static final String MAAT_API_REGISTRATION_ID = "maat-api";
+    private static final String EVIDENCE_REGISTRATION_ID = "evidence";
     private static final String CDA_API_CLIENT_BEAN = "cdaApiClient";
     private static final String MAAT_API_CLIENT_BEAN = "maatApiClient";
+    private static final String EVIDENCE_API_CLIENT_BEAN = "evidenceApiClient";
     private static final String REGISTRATION_PREFIX = "spring.security.oauth2.client.registration";
     private static final String REGISTRATION_KEY_NAME =
             "org.springframework.security.oauth2.client.OAuth2AuthorizedClient.CLIENT_REGISTRATION_ID";
@@ -117,6 +119,23 @@ class RestClientAutoConfigurationTest {
                 .withPropertyValues(getOAuthPropertyValuesForClient(MAAT_API_REGISTRATION_ID))
                 .withPropertyValues(OAUTH_CLIENT_PROVIDER_PREFIX + ".maat-api.token-uri=mock-url")
                 .run((context) -> assertThat(context).hasBean(MAAT_API_CLIENT_BEAN));
+    }
+
+    @Test
+    void evidenceApiClientIsConditionalOnOauthConfiguration() {
+        this.contextRunner
+                .withUserConfiguration(TestConfig.class, WebClientAutoConfiguration.class)
+                .withPropertyValues(getOAuthPropertyValuesForClient(EVIDENCE_REGISTRATION_ID))
+                .run((context) -> assertThat(context).doesNotHaveBean(EVIDENCE_API_CLIENT_BEAN));
+    }
+
+    @Test
+    void restApiClientConfigurerConfiguresEvidenceApiClient() {
+        this.contextRunner
+                .withUserConfiguration(TestConfig.class, WebClientAutoConfiguration.class)
+                .withPropertyValues(getOAuthPropertyValuesForClient(EVIDENCE_REGISTRATION_ID))
+                .withPropertyValues(OAUTH_CLIENT_PROVIDER_PREFIX + ".evidence.token-uri=mock-url")
+                .run((context) -> assertThat(context).hasBean(EVIDENCE_API_CLIENT_BEAN));
     }
 
     @Test


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-516)

- Auto-configuration for new evidenceAPIClient bean. This will enable services that utilise the library to call the evidence service via a dedicated web client.
- New auto-configuration test cases to ensure the new bean is correctly initialised.
