### PR TITLE
LCAM-622

### DIFF
--- a/crime-commons-spring-boot-starter-rest-client/build.gradle
+++ b/crime-commons-spring-boot-starter-rest-client/build.gradle
@@ -22,6 +22,8 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-webflux"
     implementation "org.springframework.boot:spring-boot-starter-oauth2-client"
 
+    implementation "org.eclipse.jetty:jetty-reactive-httpclient:3.0.8"
+
     compileOnly "org.projectlombok:lombok"
 
     implementation "org.jetbrains:annotations:23.0.0"

--- a/crime-commons-spring-boot-starter-rest-client/src/test/java/uk/gov/justice/laa/crime/commons/config/RestClientAutoConfigurationTest.java
+++ b/crime-commons-spring-boot-starter-rest-client/src/test/java/uk/gov/justice/laa/crime/commons/config/RestClientAutoConfigurationTest.java
@@ -45,12 +45,6 @@ class RestClientAutoConfigurationTest {
             );
 
     @Test
-    void configurationRegistersConnectionProviderBean() {
-        this.contextRunner
-                .run((context) -> assertThat(context).hasSingleBean(ConnectionProvider.class));
-    }
-
-    @Test
     void restClientConfigurerConfiguresWebClientCustomizer() {
         this.contextRunner
                 .withUserConfiguration(TestConfig.class, WebClientAutoConfiguration.class)


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-622)

Replace ReactorClientHttpConnector with Jetty alternative which supports cookies. This also meant removing a custom ConnectionProvider bean that was being used to configure timeouts etc. Having looked at what Jetty is doing, it seems to be settings sensible defaults, so I've chosen not to add any additional configuration.