### PR TITLE
LCAM-640

### DIFF
--- a/crime-commons-samples/src/main/java/uk/gov/justice/laa/crime/samples/DemoApplication.java
+++ b/crime-commons-samples/src/main/java/uk/gov/justice/laa/crime/samples/DemoApplication.java
@@ -4,10 +4,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.justice.laa.crime.samples.model.FinancialAssessment;
+import uk.gov.justice.laa.crime.samples.model.RepOrderCCOutcome;
 import uk.gov.justice.laa.crime.samples.service.DemoClientService;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -17,9 +20,14 @@ public class DemoApplication {
 
 	private final DemoClientService demoClientService;
 
-	@GetMapping("/")
-	public FinancialAssessment home() {
-		return demoClientService.getFinancialAssessment(1000);
+	@GetMapping("/financial-assessments/{id}")
+	public FinancialAssessment financialAssessment(@PathVariable int id) {
+		return demoClientService.getFinancialAssessment(id);
+	}
+
+	@GetMapping("/outcomes/{repId}")
+	public List<RepOrderCCOutcome> outcomes(@PathVariable int repId) {
+		return demoClientService.getRepOrderCCOutcomeByRepId(repId);
 	}
 
 	@GetMapping("/cda")

--- a/crime-commons-samples/src/main/java/uk/gov/justice/laa/crime/samples/model/RepOrderCCOutcome.java
+++ b/crime-commons-samples/src/main/java/uk/gov/justice/laa/crime/samples/model/RepOrderCCOutcome.java
@@ -1,0 +1,27 @@
+package uk.gov.justice.laa.crime.samples.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class RepOrderCCOutcome {
+
+    private int id;
+    private int repId;
+    private String outcome;
+    private String description;
+    private LocalDateTime outcomeDate;
+    private String userCreated;
+    private LocalDateTime dateCreated;
+    private String caseNumber;
+    private String crownCourtCode;
+    private String userModified;
+    private LocalDateTime dateModified;
+}

--- a/crime-commons-samples/src/main/java/uk/gov/justice/laa/crime/samples/service/DemoClientService.java
+++ b/crime-commons-samples/src/main/java/uk/gov/justice/laa/crime/samples/service/DemoClientService.java
@@ -4,12 +4,15 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import uk.gov.justice.laa.crime.commons.client.RestAPIClient;
 import uk.gov.justice.laa.crime.samples.model.FinancialAssessment;
+import uk.gov.justice.laa.crime.samples.model.RepOrderCCOutcome;
 
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -34,10 +37,21 @@ public class DemoClientService {
 
     public FinancialAssessment getFinancialAssessment(int financialAssessmentId) {
         FinancialAssessment response = maatApiClient.get(
-                FinancialAssessment.class,
+                new ParameterizedTypeReference<FinancialAssessment>() {},
                 maatApiBaseUrl + "/financial-assessments/{financialAssessmentId}",
                 Map.of("LAA_TRANSACTION_ID", UUID.randomUUID().toString()),
                 financialAssessmentId
+        );
+        log.info(String.format(RESPONSE_STRING, response));
+        return response;
+    }
+
+    public List<RepOrderCCOutcome> getRepOrderCCOutcomeByRepId(int repId) {
+        List<RepOrderCCOutcome> response = maatApiClient.get(
+                new ParameterizedTypeReference<List<RepOrderCCOutcome>>() {},
+                maatApiBaseUrl + "/rep-orders/cc-outcome/reporder/{repId}",
+                Map.of("LAA_TRANSACTION_ID", UUID.randomUUID().toString()),
+                repId
         );
         log.info(String.format(RESPONSE_STRING, response));
         return response;
@@ -49,7 +63,7 @@ public class DemoClientService {
         queryParams.add("publish_to_queue", "true");
 
         cdaApiClient.get(
-                Void.class,
+                new ParameterizedTypeReference<Void>() {},
                 cdaBaseUrl + "/api/internal/v2/hearing_results/{hearingId}",
                 Map.of("X-Request-ID", laaTransactionId),
                 queryParams,

--- a/crime-commons-spring-boot-starter-rest-client/src/main/java/uk/gov/justice/laa/crime/commons/client/RestAPIClient.java
+++ b/crime-commons-spring-boot-starter-rest-client/src/main/java/uk/gov/justice/laa/crime/commons/client/RestAPIClient.java
@@ -3,6 +3,7 @@ package uk.gov.justice.laa.crime.commons.client;
 import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ReactiveHttpOutputMessage;
 import org.springframework.http.ResponseEntity;
@@ -39,7 +40,7 @@ public class RestAPIClient {
      * @param url          the url
      * @param headers      the map of headers
      * @param urlVariables the map of url variables
-     * @return             the response entity (without a body)
+     * @return the response entity (without a body)
      */
     public ResponseEntity<Void> head(String url, Map<String, String> headers, Object... urlVariables) {
         return getBodilessApiResponse(null, url, headers, HttpMethod.HEAD, null, urlVariables);
@@ -48,77 +49,77 @@ public class RestAPIClient {
     /**
      * Sends a HTTP GET request
      *
-     * @param <T>           the return type
-     * @param responseClass the class used to decode the response body
-     * @param url           the url
-     * @param headers       the map of headers
-     * @param queryParams   the map of query parameters
-     * @param urlVariables  the map of url variables
-     * @return              the decoded response body
+     * @param <R>          the return type
+     * @param url          the url
+     * @param headers      the map of headers
+     * @param queryParams  the map of query parameters
+     * @param urlVariables the map of url variables
+     * @param typeReference specifies the class/type used for deserialization
+     * @return the decoded response body
      */
-    public <T> T get(Class<T> responseClass,
+    public <R> R get(ParameterizedTypeReference<R> typeReference,
                      String url,
                      Map<String, String> headers,
                      MultiValueMap<String, String> queryParams,
                      Object... urlVariables) {
-        return getApiResponse(null, responseClass, url, headers, HttpMethod.GET, queryParams, urlVariables);
+        return getApiResponse(null, typeReference, url, headers, HttpMethod.GET, queryParams, urlVariables);
     }
 
     /**
      * Sends a HTTP GET request
      *
-     * @param <T>           the return type
-     * @param responseClass the class used to decode the response body
-     * @param url           the url
-     * @param headers       the map of headers
-     * @param urlVariables  the map of url variables
-     * @return              the decoded response body
+     * @param <R>          the return type
+     * @param typeReference specifies the class/type used for deserialization
+     * @param url          the url
+     * @param headers      the map of headers
+     * @param urlVariables the map of url variables
+     * @return the decoded response body
      */
-    public <T> T get(Class<T> responseClass, String url, Map<String, String> headers, Object... urlVariables) {
-        return getApiResponse(null, responseClass, url, headers, HttpMethod.GET, null, urlVariables);
+    public <R> R get(ParameterizedTypeReference<R> typeReference, String url, Map<String, String> headers, Object... urlVariables) {
+        return getApiResponse(null, typeReference, url, headers, HttpMethod.GET, null, urlVariables);
     }
 
     /**
      * Sends a HTTP GET request
      *
-     * @param <T>           the return type
-     * @param responseClass the class used to decode the response body
-     * @param url           the url
-     * @param urlVariables  the map of url variables
-     * @return              the decoded response body
+     * @param <R>          the return type
+     * @param typeReference specifies the class/type used for deserialization
+     * @param url          the url
+     * @param urlVariables the map of url variables
+     * @return the decoded response body
      */
-    public <T> T get(Class<T> responseClass, String url, Object... urlVariables) {
-        return getApiResponse(null, responseClass, url, null, HttpMethod.GET, null, urlVariables);
+    public <R> R get(ParameterizedTypeReference<R> typeReference, String url, Object... urlVariables) {
+        return getApiResponse(null, typeReference, url, null, HttpMethod.GET, null, urlVariables);
     }
 
     /**
      * Sends a HTTP POST request
      *
-     * @param <T>           the type of the request body
-     * @param <R>           the return type
-     * @param requestBody   the request body
-     * @param responseClass the class used to decode the response body
-     * @param url           the url
-     * @param headers       the map of headers
-     * @return              the decoded response body
+     * @param <T>          the type of the request body
+     * @param <R>          the return type
+     * @param requestBody  the request body
+     * @param typeReference specifies the class/type used for deserialization
+     * @param url          the url
+     * @param headers      the map of headers
+     * @return the decoded response body
      */
-    public <T, R> R post(T requestBody, Class<R> responseClass, String url, Map<String, String> headers) {
-        return getApiResponse(requestBody, responseClass, url, headers, HttpMethod.POST, null);
+    public <T, R> R post(T requestBody, ParameterizedTypeReference<R> typeReference, String url, Map<String, String> headers) {
+        return getApiResponse(requestBody, typeReference, url, headers, HttpMethod.POST, null);
     }
 
     /**
      * Sends a HTTP PUT request
      *
-     * @param <T>           the type of the request body
-     * @param <R>           the return type
-     * @param requestBody   the request body
-     * @param responseClass the class used to decode the response body
-     * @param url           the url
-     * @param headers       the map of headers
-     * @return              the decoded response body
+     * @param <T>          the type of the request body
+     * @param <R>          the return type
+     * @param requestBody  the request body
+     * @param typeReference specifies the class/type used for deserialization
+     * @param url          the url
+     * @param headers      the map of headers
+     * @return the decoded response body
      */
-    public <T, R> R put(T requestBody, Class<R> responseClass, String url, Map<String, String> headers) {
-        return getApiResponse(requestBody, responseClass, url, headers, HttpMethod.PUT, null);
+    public <T, R> R put(T requestBody, ParameterizedTypeReference<R> typeReference, String url, Map<String, String> headers) {
+        return getApiResponse(requestBody, typeReference, url, headers, HttpMethod.PUT, null);
     }
 
     private <T> WebClient.RequestHeadersSpec<?> prepareRequest(T requestBody,
@@ -158,16 +159,16 @@ public class RestAPIClient {
      * @param <T>           the type of the request body
      * @param <R>           the return type
      * @param requestBody   the request body
-     * @param responseClass the class used to decode the response body
+     * @param typeReference  specifies the class/type used for deserialization
      * @param url           the url
      * @param headers       the map of headers
      * @param requestMethod the HTTP request method
      * @param queryParams   the map of query parameters
      * @param urlVariables  the map of url variables
-     * @return              the decoded api response body
+     * @return the decoded api response body
      */
     <T, R> R getApiResponse(T requestBody,
-                            Class<R> responseClass,
+                            ParameterizedTypeReference<R> typeReference,
                             String url,
                             Map<String, String> headers,
                             HttpMethod requestMethod,
@@ -176,7 +177,7 @@ public class RestAPIClient {
 
         WebClient.RequestHeadersSpec<?> requestHeadersSpec =
                 prepareRequest(requestBody, url, headers, requestMethod, queryParams, urlVariables);
-        return configureErrorResponse(requestHeadersSpec.retrieve().bodyToMono(responseClass)).block();
+        return configureErrorResponse(requestHeadersSpec.retrieve().bodyToMono(typeReference)).block();
     }
 
     /**
@@ -189,7 +190,7 @@ public class RestAPIClient {
      * @param requestMethod the HTTP request method
      * @param queryParams   the map of query parameters
      * @param urlVariables  the map of url variables
-     * @return              the response entity (without a body)
+     * @return the response entity (without a body)
      */
     <T> ResponseEntity<Void> getBodilessApiResponse(T requestBody,
                                                     String url,

--- a/crime-commons-spring-boot-starter-rest-client/src/test/java/uk/gov/justice/laa/crime/commons/client/RestAPIClientTest.java
+++ b/crime-commons-spring-boot-starter-rest-client/src/test/java/uk/gov/justice/laa/crime/commons/client/RestAPIClientTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -79,10 +80,12 @@ class RestAPIClientTest {
             throws JsonProcessingException {
 
         MockRequestBody request = new MockRequestBody();
+        ParameterizedTypeReference<MockResponse> typeReference = new ParameterizedTypeReference<>() {
+        };
         setupValidResponseTest(new MockResponse(MOCK_REP_ID));
-        restAPIClient.post(request, MockResponse.class, MOCK_URL, null);
+        restAPIClient.post(request, typeReference, MOCK_URL, null);
         verify(restAPIClient)
-                .getApiResponse(request, MockResponse.class, MOCK_URL, null, HttpMethod.POST, null);
+                .getApiResponse(request, typeReference, MOCK_URL, null, HttpMethod.POST, null);
     }
 
     @Test
@@ -91,10 +94,18 @@ class RestAPIClientTest {
 
         MockRequestBody request = new MockRequestBody();
         setupValidResponseTest(new MockResponse(MOCK_REP_ID));
-        restAPIClient.put(request, MockResponse.class, MOCK_URL, MOCK_HEADERS);
+        ParameterizedTypeReference<MockResponse> typeReference = new ParameterizedTypeReference<>() {
+        };
+        restAPIClient.put(request, typeReference, MOCK_URL, MOCK_HEADERS);
 
         verify(restAPIClient)
-                .getApiResponse(request, MockResponse.class, MOCK_URL, MOCK_HEADERS, HttpMethod.PUT, null);
+                .getApiResponse(request,
+                        typeReference,
+                        MOCK_URL,
+                        MOCK_HEADERS,
+                        HttpMethod.PUT,
+                        null
+                );
     }
 
     @Test
@@ -105,19 +116,33 @@ class RestAPIClientTest {
         restAPIClient.head(MOCK_URL, MOCK_HEADERS);
 
         verify(restAPIClient)
-                .getBodilessApiResponse(null, MOCK_URL, MOCK_HEADERS, HttpMethod.HEAD, null);
+                .getBodilessApiResponse(
+                        null,
+                        MOCK_URL,
+                        MOCK_HEADERS,
+                        HttpMethod.HEAD,
+                        null
+                );
     }
 
     @Test
     void givenCorrectParams_whenGetIsInvoked_thenGetApiResponseIsCalled()
             throws JsonProcessingException {
 
-
         setupValidResponseTest(new MockResponse(MOCK_REP_ID));
-        restAPIClient.get(MockResponse.class, MOCK_URL, MOCK_REP_ID);
+        ParameterizedTypeReference<MockResponse> typeReference = new ParameterizedTypeReference<>() {
+        };
+        restAPIClient.get(typeReference, MOCK_URL, MOCK_REP_ID);
 
         verify(restAPIClient)
-                .getApiResponse(null, MockResponse.class, MOCK_URL, null, HttpMethod.GET, null, MOCK_REP_ID);
+                .getApiResponse(
+                        null,
+                        typeReference, MOCK_URL,
+                        null,
+                        HttpMethod.GET,
+                        null,
+                        MOCK_REP_ID
+                );
     }
 
     @Test
@@ -125,24 +150,41 @@ class RestAPIClientTest {
             throws JsonProcessingException {
 
         setupValidResponseTest(new MockResponse(MOCK_REP_ID));
-        restAPIClient.get(MockResponse.class, MOCK_URL, MOCK_HEADERS, MOCK_REP_ID);
+        ParameterizedTypeReference<MockResponse> typeReference = new ParameterizedTypeReference<>() {
+        };
+        restAPIClient.get(typeReference, MOCK_URL, MOCK_HEADERS, MOCK_REP_ID);
 
         verify(restAPIClient)
-                .getApiResponse(null, MockResponse.class, MOCK_URL, MOCK_HEADERS, HttpMethod.GET, null, MOCK_REP_ID);
+                .getApiResponse(null,
+                        typeReference,
+                        MOCK_URL,
+                        MOCK_HEADERS,
+                        HttpMethod.GET,
+                        null,
+                        MOCK_REP_ID
+                );
     }
 
     @Test
     void givenCorrectParams_whenGetIsInvokedWithQueryParams_thenGetApiResponseIsCalled()
             throws JsonProcessingException {
 
+        setupValidResponseTest(new MockResponse(MOCK_REP_ID));
         MultiValueMapAdapter<String, String> queryParams =
                 new MultiValueMapAdapter<>(Map.of("id", List.of("1000")));
-
-        setupValidResponseTest(new MockResponse(MOCK_REP_ID));
-        restAPIClient.get(MockResponse.class, MOCK_URL, MOCK_HEADERS, queryParams);
+        ParameterizedTypeReference<MockResponse> typeReference = new ParameterizedTypeReference<>() {
+        };
+        restAPIClient.get(typeReference, MOCK_URL, MOCK_HEADERS, queryParams);
 
         verify(restAPIClient)
-                .getApiResponse(null, MockResponse.class, MOCK_URL, MOCK_HEADERS, HttpMethod.GET, queryParams);
+                .getApiResponse(
+                        null,
+                        typeReference,
+                        MOCK_URL,
+                        MOCK_HEADERS,
+                        HttpMethod.GET,
+                        queryParams
+                );
     }
 
     @Test
@@ -152,7 +194,8 @@ class RestAPIClientTest {
         setupValidResponseTest(new MockResponse(MOCK_REP_ID));
         MockResponse apiResponse = restAPIClient.getApiResponse(
                 new MockRequestBody(),
-                MockResponse.class,
+                new ParameterizedTypeReference<MockResponse>() {
+                },
                 MOCK_URL,
                 MOCK_HEADERS,
                 HttpMethod.POST,
@@ -182,7 +225,8 @@ class RestAPIClientTest {
         assertThatThrownBy(
                 () -> restAPIClient.getApiResponse(
                         new MockRequestBody(),
-                        ClientResponse.class,
+                        new ParameterizedTypeReference<MockResponse>() {
+                        },
                         MOCK_URL,
                         MOCK_HEADERS,
                         HttpMethod.POST,
@@ -196,9 +240,10 @@ class RestAPIClientTest {
     @Test
     void givenAnInvalidUrl_whenGetApiResponseIsInvoked_thenReturnsNull() {
         setupNotFoundTest();
-        ClientResponse response = restAPIClient.getApiResponse(
+        MockResponse response = restAPIClient.getApiResponse(
                 new MockRequestBody(),
-                ClientResponse.class,
+                new ParameterizedTypeReference<MockResponse>() {
+                },
                 MOCK_URL,
                 MOCK_HEADERS,
                 HttpMethod.POST,
@@ -210,9 +255,10 @@ class RestAPIClientTest {
     @Test
     void givenANotFoundException_whenGetApiResponseIsInvoked_thenReturnsNull() {
         setupNotFoundTest();
-        ClientResponse response = restAPIClient.getApiResponse(
+        MockResponse response = restAPIClient.getApiResponse(
                 new MockRequestBody(),
-                ClientResponse.class,
+                new ParameterizedTypeReference<MockResponse>() {
+                },
                 MOCK_URL,
                 MOCK_HEADERS,
                 HttpMethod.GET,
@@ -220,6 +266,26 @@ class RestAPIClientTest {
                 MOCK_REP_ID
         );
         assertThat(response).isNull();
+    }
+
+    @Test
+    void givenParameterizedResponseSpec_whenGetApiResponseIsInvoked_thenResponseIsCorrectlyDeserialized()
+            throws JsonProcessingException {
+
+        List<MockResponse> expected =
+                List.of(new MockResponse("1"), new MockResponse("2"));
+
+        setupValidResponseTest(expected);
+        List<MockResponse> response = restAPIClient.getApiResponse(
+                new MockRequestBody(),
+                new ParameterizedTypeReference<List<MockResponse>>() {},
+                MOCK_URL,
+                MOCK_HEADERS,
+                HttpMethod.GET,
+                null,
+                MOCK_REP_ID
+        );
+        assertThat(response).isEqualTo(expected);
     }
 
     private void setupNotFoundTest() {


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-640)

- Enable passing compound response types to REST API clients. This has been achieved by altering method signatures to accept a `ParameterizedTypeReference` rather than a class. `ParameterizedTypeReference` is able to capture and pass a generic type (including collections) and retain it at runtime, sidestepping type erasure issues.
- Updated test cases and added an additional scenario around handling collections.
- Updated the sample project in line with the above changes.