### PR TITLE
LCAM-807: Updates to set webclient max_in_memory_size

### DIFF
--- a/crime-commons-spring-boot-starter-rest-client/src/main/java/uk/gov/justice/laa/crime/commons/common/Constants.java
+++ b/crime-commons-spring-boot-starter-rest-client/src/main/java/uk/gov/justice/laa/crime/commons/common/Constants.java
@@ -14,4 +14,11 @@ public class Constants {
      * Used to trace requests spanning multiple LAA crime microservices
      */
     public static final String LAA_TRANSACTION_ID = "Laa-Transaction-Id";
+
+    /**
+     * The constant MAX_IN_MEMORY_SIZE
+     * Used to limit the number of bytes that can be buffered by the WebClient whenever the input stream needs to be aggregated.
+     */
+    public static final int MAX_IN_MEMORY_SIZE = 10485760;
+
 }

--- a/crime-commons-spring-boot-starter-rest-client/src/main/java/uk/gov/justice/laa/crime/commons/config/RestClientAutoConfiguration.java
+++ b/crime-commons-spring-boot-starter-rest-client/src/main/java/uk/gov/justice/laa/crime/commons/config/RestClientAutoConfiguration.java
@@ -35,7 +35,7 @@ import java.util.function.Consumer;
 @EnableConfigurationProperties(RetryConfiguration.class)
 public class RestClientAutoConfiguration {
 
-    private static int MAX_IN_MEMORY_SIZE = 4194304; //Limit on the number of bytes that can be buffered whenever the input stream needs to be aggregated.
+    private static int MAX_IN_MEMORY_SIZE = 10485760; //Limit on the number of bytes that can be buffered whenever the input stream needs to be aggregated.
     private final RetryConfiguration retryConfiguration;
 
 

--- a/crime-commons-spring-boot-starter-rest-client/src/main/java/uk/gov/justice/laa/crime/commons/config/RestClientAutoConfiguration.java
+++ b/crime-commons-spring-boot-starter-rest-client/src/main/java/uk/gov/justice/laa/crime/commons/config/RestClientAutoConfiguration.java
@@ -18,6 +18,7 @@ import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepo
 import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.WebClient;
 import uk.gov.justice.laa.crime.commons.client.RestAPIClient;
+import uk.gov.justice.laa.crime.commons.common.Constants;
 import uk.gov.justice.laa.crime.commons.filters.WebClientFilters;
 
 import java.util.Map;
@@ -35,7 +36,6 @@ import java.util.function.Consumer;
 @EnableConfigurationProperties(RetryConfiguration.class)
 public class RestClientAutoConfiguration {
 
-    private static int MAX_IN_MEMORY_SIZE = 10485760; //Limit on the number of bytes that can be buffered whenever the input stream needs to be aggregated.
     private final RetryConfiguration retryConfiguration;
 
 
@@ -62,7 +62,7 @@ public class RestClientAutoConfiguration {
 
             webClientBuilder.defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
             webClientBuilder.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
-            webClientBuilder.codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(MAX_IN_MEMORY_SIZE));
+            webClientBuilder.codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(Constants.MAX_IN_MEMORY_SIZE));
 
             webClientBuilder.filters(filters -> {
                 filters.add(WebClientFilters.logResponse());

--- a/crime-commons-spring-boot-starter-rest-client/src/main/java/uk/gov/justice/laa/crime/commons/config/RestClientAutoConfiguration.java
+++ b/crime-commons-spring-boot-starter-rest-client/src/main/java/uk/gov/justice/laa/crime/commons/config/RestClientAutoConfiguration.java
@@ -35,6 +35,7 @@ import java.util.function.Consumer;
 @EnableConfigurationProperties(RetryConfiguration.class)
 public class RestClientAutoConfiguration {
 
+    private static int MAX_IN_MEMORY_SIZE = 4194304; //Limit on the number of bytes that can be buffered whenever the input stream needs to be aggregated.
     private final RetryConfiguration retryConfiguration;
 
 
@@ -61,6 +62,7 @@ public class RestClientAutoConfiguration {
 
             webClientBuilder.defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
             webClientBuilder.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+            webClientBuilder.codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(MAX_IN_MEMORY_SIZE));
 
             webClientBuilder.filters(filters -> {
                 filters.add(WebClientFilters.logResponse());


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-807)

Describe what you did and why.

Updated the Spring WebClient builder to set maxInMemorySize to 10MB. The current default value of 2KB is causing DataBufferLimitException.  