### PR TITLE
Add request builder util methods for passing transaction id

### DIFF
--- a/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/util/RequestBuilderUtils.java
+++ b/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/util/RequestBuilderUtils.java
@@ -12,6 +12,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 public class RequestBuilderUtils {
 
     private static final String MOCK_TOKEN = "token";
+    private static final String LAA_TRANSACTION_ID = "Laa-Transaction-Id";
 
     public static MockHttpServletRequestBuilder buildRequestGivenContent(HttpMethod method, String content, String endpointUrl) {
         return buildRequestGivenContent(method, content, endpointUrl, true);
@@ -34,6 +35,29 @@ public class RequestBuilderUtils {
 
     public static MockHttpServletRequestBuilder buildRequest(HttpMethod method, String endpoint, boolean withAuth) {
         MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.request(method, endpoint);
+        if (withAuth) {
+            requestBuilder.header(HttpHeaders.AUTHORIZATION, "Bearer " + MOCK_TOKEN);
+        }
+        return requestBuilder;
+    }
+
+    public static MockHttpServletRequestBuilder buildRequestWithTransactionId(HttpMethod method, String endpoint, boolean withAuth) {
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
+                .request(method, endpoint)
+                .header(LAA_TRANSACTION_ID, "laa-transaction-id");
+        if (withAuth) {
+            requestBuilder.header(HttpHeaders.AUTHORIZATION, "Bearer " + MOCK_TOKEN);
+        }
+        return requestBuilder;
+    }
+
+    public static MockHttpServletRequestBuilder buildRequestWithTransactionIdGivenContent(
+            HttpMethod method, String content, String endpointUrl, boolean withAuth) {
+        MockHttpServletRequestBuilder requestBuilder =
+                MockMvcRequestBuilders.request(method, endpointUrl)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(LAA_TRANSACTION_ID, "laa-transaction-id")
+                        .content(content);
         if (withAuth) {
             requestBuilder.header(HttpHeaders.AUTHORIZATION, "Bearer " + MOCK_TOKEN);
         }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1150)

Added request builder util methods for passing transaction id in the header.