### PR TITLE
LCAM 1105 Integration Tests for Means Assessment Flow

### DIFF
--- a/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/enums/CrownCourtOutcome.java
+++ b/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/enums/CrownCourtOutcome.java
@@ -10,14 +10,14 @@ import java.util.stream.Stream;
 @AllArgsConstructor
 public enum CrownCourtOutcome {
 
-    ABANDONED("ABANDONED", CrownCourtOutcomeType.TRIAL, "Abandoned"),
-    AQUITTED("AQUITTED", CrownCourtOutcomeType.TRIAL, "Acquitted"),
-    CONVICTED("CONVICTED", CrownCourtOutcomeType.TRIAL, "Convicted"),
-    DISMISSED("DISMISSED", CrownCourtOutcomeType.TRIAL, "Dismissed"),
-    PART_CONVICTED("PART CONVICTED", CrownCourtOutcomeType.TRIAL, "Partially Convicted"),
-    PART_SUCCESS("PART SUCCESS", CrownCourtOutcomeType.APPEAL, "Partially Successful"),
-    SUCCESSFUL("SUCCESSFUL", CrownCourtOutcomeType.APPEAL, "Successful"),
-    UNSUCCESSFUL("UNSUCCESSFUL", CrownCourtOutcomeType.APPEAL, "Unsuccessful");
+    ABANDONED("ABANDONED", CrownCourtOutcomeType.TRIAL.getType(), "Abandoned"),
+    AQUITTED("AQUITTED", CrownCourtOutcomeType.TRIAL.getType(), "Acquitted"),
+    CONVICTED("CONVICTED", CrownCourtOutcomeType.TRIAL.getType(), "Convicted"),
+    DISMISSED("DISMISSED", CrownCourtOutcomeType.TRIAL.getType(), "Dismissed"),
+    PART_CONVICTED("PART CONVICTED", CrownCourtOutcomeType.TRIAL.getType(), "Partially Convicted"),
+    PART_SUCCESS("PART SUCCESS", CrownCourtOutcomeType.APPEAL.getType(), "Partially Successful"),
+    SUCCESSFUL("SUCCESSFUL", CrownCourtOutcomeType.APPEAL.getType(), "Successful"),
+    UNSUCCESSFUL("UNSUCCESSFUL", CrownCourtOutcomeType.APPEAL.getType(), "Unsuccessful");
 
     private final String code;
     private final String type;
@@ -30,10 +30,5 @@ public enum CrownCourtOutcome {
                 .filter(crownCourtOutcome -> crownCourtOutcome.code.equals(code))
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException(String.format("Crown Court Outcome with value: %s does not exist.", code)));
-    }
-
-    private static class CrownCourtOutcomeType {
-        private static final String TRIAL = "TRIAL";
-        private static final String APPEAL = "APPEAL";
     }
 }

--- a/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/enums/CrownCourtOutcomeType.java
+++ b/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/enums/CrownCourtOutcomeType.java
@@ -1,0 +1,24 @@
+package uk.gov.justice.laa.crime.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.stream.Stream;
+
+@Getter
+@AllArgsConstructor
+public enum CrownCourtOutcomeType {
+    TRIAL("TRIAL"), APPEAL("APPEAL");
+
+    private final String type;
+
+    public static CrownCourtOutcomeType getFrom(String type) {
+        if (StringUtils.isBlank(type)) return null;
+
+        return Stream.of(CrownCourtOutcomeType.values())
+                .filter(ccoType -> ccoType.type.equals(type))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(String.format("CrownCourtOutcomeType with value: %s does not exist.", type)));
+    }
+}

--- a/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/enums/CrownCourtOutcomeType.java
+++ b/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/enums/CrownCourtOutcomeType.java
@@ -19,6 +19,6 @@ public enum CrownCourtOutcomeType {
         return Stream.of(CrownCourtOutcomeType.values())
                 .filter(ccoType -> ccoType.type.equals(type))
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException(String.format("CrownCourtOutcomeType with value: %s does not exist.", type)));
+                .orElseThrow(() -> new IllegalArgumentException(String.format("CrownCourtOutcomeType with value: [%s] does not exist.", type)));
     }
 }

--- a/crime-commons-classes/src/test/java/uk/gov/justice/laa/crime/enums/CrownCourtOutcomeTypeTest.java
+++ b/crime-commons-classes/src/test/java/uk/gov/justice/laa/crime/enums/CrownCourtOutcomeTypeTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
-public class CrownCourtOutcomeTypeTest {
+class CrownCourtOutcomeTypeTest {
 
     @Test
     void givenValidType_whenGetFromIsInvoked_thenCorrectEnumIsReturned() {
@@ -14,7 +14,7 @@ public class CrownCourtOutcomeTypeTest {
 
     @Test
     void givenBlankString_whenGetFromIsInvoked_thenNullIsReturned() {
-        assertThat(CrownCourtOutcomeType.getFrom("")).isEqualTo(null);
+        assertThat(CrownCourtOutcomeType.getFrom("")).isNull();
     }
 
     @Test

--- a/crime-commons-classes/src/test/java/uk/gov/justice/laa/crime/enums/CrownCourtOutcomeTypeTest.java
+++ b/crime-commons-classes/src/test/java/uk/gov/justice/laa/crime/enums/CrownCourtOutcomeTypeTest.java
@@ -1,0 +1,29 @@
+package uk.gov.justice.laa.crime.enums;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+public class CrownCourtOutcomeTypeTest {
+
+    @Test
+    void givenValidType_whenGetFromIsInvoked_thenCorrectEnumIsReturned() {
+        assertThat(CrownCourtOutcomeType.getFrom("TRIAL")).isEqualTo(CrownCourtOutcomeType.TRIAL);
+    }
+
+    @Test
+    void givenBlankString_whenGetFromIsInvoked_thenNullIsReturned() {
+        assertThat(CrownCourtOutcomeType.getFrom("")).isEqualTo(null);
+    }
+
+    @Test
+    void givenInvalidType_whenGetFromIsInvoked_thenExceptionIsRaised() {
+        assertThatThrownBy(() -> CrownCourtOutcomeType.getFrom("FLIBBLE")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void givenValidInput_ValidateEnumValues() {
+        assertThat("APPEAL").isEqualTo(CrownCourtOutcomeType.APPEAL.getType());
+    }
+}


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/projects/LCAM/boards/881?selectedIssue=LCAM-1105)

Changed CrownCourtOutcomeType enum to be public so it can be accessed from any project that uses this module (in particular orchestration for a fix highlighted by the integration tests) and also added unit tests for the new enum.
