### PR TITLE
LCAM 1259 Remove Internal Server Error From List of Retriable Errors

### DIFF
--- a/crime-commons-spring-boot-starter-rest-client/src/main/java/uk/gov/justice/laa/crime/commons/filters/WebClientFilters.java
+++ b/crime-commons-spring-boot-starter-rest-client/src/main/java/uk/gov/justice/laa/crime/commons/filters/WebClientFilters.java
@@ -83,7 +83,7 @@ public class WebClientFilters {
 
         List<HttpStatus> retryableStatuses = List.of(
                 HttpStatus.REQUEST_TIMEOUT, HttpStatus.TOO_EARLY, HttpStatus.TOO_MANY_REQUESTS, HttpStatus.BAD_GATEWAY,
-                HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.SERVICE_UNAVAILABLE, HttpStatus.GATEWAY_TIMEOUT
+                HttpStatus.SERVICE_UNAVAILABLE, HttpStatus.GATEWAY_TIMEOUT
         );
 
         return ExchangeFilterFunctions.statusError(

--- a/crime-commons-spring-boot-starter-rest-client/src/test/java/uk/gov/justice/laa/crime/commons/filters/WebClientFiltersTest.java
+++ b/crime-commons-spring-boot-starter-rest-client/src/test/java/uk/gov/justice/laa/crime/commons/filters/WebClientFiltersTest.java
@@ -170,7 +170,7 @@ class WebClientFiltersTest {
                 .when(exchangeFunction).exchange(request);
 
         when(clientResponse.statusCode())
-                .thenReturn(HttpStatus.NOT_IMPLEMENTED);
+                .thenReturn(HttpStatus.INTERNAL_SERVER_ERROR);
 
         Mono<ClientResponse> response = WebClientFilters.handleErrorResponse()
                 .filter(request, exchangeFunction);
@@ -178,7 +178,7 @@ class WebClientFiltersTest {
         assertThatThrownBy(
                 response::block
         ).isInstanceOf(HttpServerErrorException.class)
-                .hasMessage("501 Received error 501 due to Not Implemented");
+                .hasMessage("500 Received error 500 due to Internal Server Error");
     }
 
     @Test
@@ -188,7 +188,7 @@ class WebClientFiltersTest {
                 .when(exchangeFunction).exchange(request);
 
         when(clientResponse.statusCode())
-                .thenReturn(HttpStatus.INTERNAL_SERVER_ERROR);
+                .thenReturn(HttpStatus.REQUEST_TIMEOUT);
 
         Mono<ClientResponse> response = WebClientFilters.handleErrorResponse()
                 .filter(request, exchangeFunction);
@@ -196,7 +196,7 @@ class WebClientFiltersTest {
         assertThatThrownBy(
                 response::block
         ).isInstanceOf(RetryableWebClientResponseException.class)
-                .hasMessage("Received error 500 due to Internal Server Error");
+                .hasMessage("Received error 408 due to Request Timeout");
     }
 
     @Test


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/projects/LCAM/boards/881?selectedIssue=LCAM-1259)

Removed Internal Server Error from the list of retriable errors defined in the handleErrorResponse filter so that they will no longer be retried.
