### PR TITLE
LASB-3244 - add residential status to capital equity

### DIFF
--- a/crime-commons-schemas/src/main/resources/schemas/crimeapplication/common/capitalEquity.json
+++ b/crime-commons-schemas/src/main/resources/schemas/crimeapplication/common/capitalEquity.json
@@ -23,6 +23,10 @@
         "$ref": "#/definitions/capitalOther"
       },
       "description": "Array of other capital"
+    },
+    "residentialStatus": {
+      "type": "string",
+      "enum": ["OWNER", "TENANT", "TEMP", "PARENTS", null]
     }
   },
   "definitions": {


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-3244)

Updated the schema to include the new residential status field between CAA and MAAT as part of C&E work.
