### PR TITLE
LASB-3326 Add filters to clear the MDC after each request and add the Laa-Transaction-Id to the MDC when available in the Header

### DIFF
--- a/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/filter/mdc/AddLaaTransactionIdToMDC.java
+++ b/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/filter/mdc/AddLaaTransactionIdToMDC.java
@@ -1,0 +1,53 @@
+package uk.gov.justice.laa.crime.filter.mdc;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.annotation.WebFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@WebFilter("/*")
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class AddLaaTransactionIdToMDC implements Filter {
+
+  private static final String LAA_TRANSACTION_ID = "Laa-Transaction-Id";
+
+  @Override
+  public void doFilter(ServletRequest request,
+      ServletResponse response,
+      FilterChain chain)
+      throws IOException, ServletException {
+
+    String laaTransactionIdHeaderValue = extractLaaTransactionIdFromHeader(request);
+
+    if(StringUtils.isNotBlank(laaTransactionIdHeaderValue)){
+      log.debug("Adding the {} [{}] to the MDC", LAA_TRANSACTION_ID, laaTransactionIdHeaderValue);
+      MDC.put(LAA_TRANSACTION_ID, laaTransactionIdHeaderValue);
+
+    } else {
+      log.debug("Not adding the {} [{}] to the MDC, as it is blank", LAA_TRANSACTION_ID, laaTransactionIdHeaderValue);
+    }
+
+    chain.doFilter(request, response);
+  }
+
+  private String extractLaaTransactionIdFromHeader(ServletRequest request) {
+
+    if (request instanceof HttpServletRequest httpServletRequest) {
+      return  httpServletRequest.getHeader(LAA_TRANSACTION_ID);
+    }
+
+    return null;
+  }
+}

--- a/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/filter/mdc/AfterFilterChainClearDownMDC.java
+++ b/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/filter/mdc/AfterFilterChainClearDownMDC.java
@@ -1,0 +1,32 @@
+package uk.gov.justice.laa.crime.filter.mdc;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.annotation.WebFilter;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@WebFilter("/*")
+@Component
+@Order
+public class AfterFilterChainClearDownMDC implements Filter {
+    
+    @Override
+    public void doFilter(ServletRequest servletRequest,
+        ServletResponse servletResponse,
+                         FilterChain filterChain) throws IOException, ServletException {
+        try {
+            filterChain.doFilter(servletRequest, servletResponse);
+        } finally {
+            log.debug("About to clear down the MDC");
+            MDC.clear();
+        }
+    }
+}

--- a/crime-commons-classes/src/test/java/uk/gov/justice/laa/crime/filter/mdc/AddLaaTransactionIdToMDCTest.java
+++ b/crime-commons-classes/src/test/java/uk/gov/justice/laa/crime/filter/mdc/AddLaaTransactionIdToMDCTest.java
@@ -1,0 +1,83 @@
+package uk.gov.justice.laa.crime.filter.mdc;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.MDC;
+
+@ExtendWith(MockitoExtension.class)
+class AddLaaTransactionIdToMDCTest {
+
+  private static final String LAA_TRANSACTION_ID = "Laa-Transaction-Id";
+
+  @Mock
+  private HttpServletRequest httpServletRequest;
+
+  @Mock
+  private ServletResponse servletResponse;
+
+  @Mock
+  private FilterChain filterChain;
+
+  private AddLaaTransactionIdToMDC filter;
+
+  @BeforeEach
+  public void setUp() {
+    MDC.clear();
+    filter = new AddLaaTransactionIdToMDC();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    MDC.clear();
+  }
+
+  @Test
+  public void doFilter_addsLaaTransactionIdToMDC_whenHeaderIsPresent()
+      throws IOException, ServletException {
+    final String laaTransactionId = "7c49ebfe-fe3a-4f2f-8dad-f7b8f03b8327";
+    when(httpServletRequest.getHeader(LAA_TRANSACTION_ID)).thenReturn(laaTransactionId);
+
+    filter.doFilter(httpServletRequest, servletResponse, filterChain);
+
+    assertEquals(laaTransactionId, MDC.get(LAA_TRANSACTION_ID));
+    verify(filterChain)
+        .doFilter(httpServletRequest, servletResponse);
+  }
+
+  @Test
+  public void doFilter_doesNotAddLaaTransactionIdToMDC_whenHeaderIsAbsent()
+      throws IOException, ServletException {
+    when(httpServletRequest.getHeader(LAA_TRANSACTION_ID)).thenReturn(null);
+
+    filter.doFilter(httpServletRequest, servletResponse, filterChain);
+
+    assertNull(MDC.get(LAA_TRANSACTION_ID));
+    verify(filterChain)
+        .doFilter(httpServletRequest, servletResponse);
+  }
+
+  @Test
+  public void doFilter_handlesNonHttpServletRequest() throws IOException, ServletException {
+    ServletRequest servletRequest = Mockito.mock(ServletRequest.class);
+    filter.doFilter(servletRequest, servletResponse, filterChain);
+
+    assertNull(MDC.get(LAA_TRANSACTION_ID));
+    verify(filterChain)
+        .doFilter(servletRequest, servletResponse);
+  }
+}

--- a/crime-commons-classes/src/test/java/uk/gov/justice/laa/crime/filter/mdc/AfterFilterChainClearDownMDCTest.java
+++ b/crime-commons-classes/src/test/java/uk/gov/justice/laa/crime/filter/mdc/AfterFilterChainClearDownMDCTest.java
@@ -1,0 +1,86 @@
+package uk.gov.justice.laa.crime.filter.mdc;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.MDC;
+
+@ExtendWith(MockitoExtension.class)
+class AfterFilterChainClearDownMDCTest {
+
+  private static final String MDC_KEY_FOR_TESTING = "mdcTestKey";
+  private static final String MDC_VALUE_FOR_TESTING = "123456";
+
+  @Mock
+  private HttpServletRequest mockHttpRequest;
+
+  @Mock
+  private HttpServletResponse mockHttpResponse;
+
+  @Mock
+  private FilterChain mockFilterChain;
+
+  private AfterFilterChainClearDownMDC filter;
+
+  @BeforeEach
+  void beforeEach() {
+    MDC.clear();
+    filter = new AfterFilterChainClearDownMDC();
+    MDC.put(MDC_KEY_FOR_TESTING, MDC_VALUE_FOR_TESTING);
+  }
+
+  @AfterEach
+  void afterEach() {
+    MDC.clear();
+  }
+
+  @Test
+  void should_ClearTheMappingDiagnosticsContext() throws ServletException, IOException {
+    assertEquals(MDC_VALUE_FOR_TESTING, getActualValueFromMDC(), "Failed precondition");
+
+    filter.doFilter(mockHttpRequest, mockHttpResponse, mockFilterChain);
+
+    assertAll(
+        () -> verify(mockFilterChain).doFilter(mockHttpRequest, mockHttpResponse),
+        () -> assertNull(getActualValueFromMDC())
+    );
+  }
+
+  @Test
+  void should_ClearTheMappingDiagnosticsContextWhenAnExceptionIsThrown()
+      throws ServletException, IOException {
+    final ServletException expectedException = new ServletException("Error processing request");
+    doThrow(expectedException)
+        .when(mockFilterChain)
+        .doFilter(mockHttpRequest, mockHttpResponse);
+    assertEquals(MDC_VALUE_FOR_TESTING, getActualValueFromMDC(), "Failed precondition");
+
+    ServletException actualException = assertThrows(ServletException.class,
+        () -> filter.doFilter(mockHttpRequest, mockHttpResponse, mockFilterChain));
+
+    assertAll(
+        () -> assertEquals(expectedException, actualException),
+        () -> verify(mockFilterChain).doFilter(mockHttpRequest, mockHttpResponse),
+        () -> assertNull(getActualValueFromMDC())
+    );
+  }
+
+  private String getActualValueFromMDC() {
+    return MDC.get(MDC_KEY_FOR_TESTING);
+  }
+}


### PR DESCRIPTION
Add filters to clear the MDC after each request and add the Laa-Transaction-Id to the MDC when available in the Header.

Changes include:
- New filter `AddLaaTransactionIdToMDC.java`
- New filter `AfterFilterChainClearDownMDC.java`

[Link to story - LASB-3326](https://dsdmoj.atlassian.net/browse/LASB-3326)

Describe what you did and why.
