### PR TITLE
LASB-3326 New FilterConfiguration @AutoConfiguration for filters

### DIFF
--- a/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/config/FilterConfiguration.java
+++ b/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/config/FilterConfiguration.java
@@ -1,0 +1,46 @@
+package uk.gov.justice.laa.crime.config;
+
+import org.slf4j.MDC;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import uk.gov.justice.laa.crime.filter.mdc.AddLaaTransactionIdToMDC;
+import uk.gov.justice.laa.crime.filter.mdc.AfterFilterChainClearDownMDC;
+
+/**
+ * Autoconfigures the filters <Code>AddLaaTransactionIdToMDC</Code> and
+ * <Code>AfterFilterChainClearDownMDC</Code>
+ */
+@Configuration
+@AutoConfiguration
+public class FilterConfiguration {
+
+  private static final String MATCH_ALL_URLS = "/*";
+
+  @Bean
+  @ConditionalOnClass(MDC.class)
+  public FilterRegistrationBean<AddLaaTransactionIdToMDC> addLaaTransactionIdToMDCFilter() {
+    FilterRegistrationBean<AddLaaTransactionIdToMDC> registrationBean = new FilterRegistrationBean<>();
+
+    registrationBean.setFilter(new AddLaaTransactionIdToMDC());
+    registrationBean.addUrlPatterns(MATCH_ALL_URLS);
+    registrationBean.setOrder(Ordered.HIGHEST_PRECEDENCE);
+
+    return registrationBean;
+  }
+
+  @Bean
+  @ConditionalOnClass(MDC.class)
+  public FilterRegistrationBean<AfterFilterChainClearDownMDC> afterFilterChainClearDownMDCFilter() {
+    FilterRegistrationBean<AfterFilterChainClearDownMDC> registrationBean = new FilterRegistrationBean<>();
+
+    registrationBean.setFilter(new AfterFilterChainClearDownMDC());
+    registrationBean.addUrlPatterns(MATCH_ALL_URLS);
+    registrationBean.setOrder(Ordered.LOWEST_PRECEDENCE);
+
+    return registrationBean;
+  }
+}

--- a/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/filter/mdc/AddLaaTransactionIdToMDC.java
+++ b/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/filter/mdc/AddLaaTransactionIdToMDC.java
@@ -5,20 +5,13 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
-import jakarta.servlet.annotation.WebFilter;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.MDC;
-import org.springframework.core.Ordered;
-import org.springframework.core.annotation.Order;
-import org.springframework.stereotype.Component;
 
 @Slf4j
-@WebFilter("/*")
-@Component
-@Order(Ordered.HIGHEST_PRECEDENCE)
 public class AddLaaTransactionIdToMDC implements Filter {
 
   private static final String LAA_TRANSACTION_ID = "Laa-Transaction-Id";
@@ -31,12 +24,13 @@ public class AddLaaTransactionIdToMDC implements Filter {
 
     String laaTransactionIdHeaderValue = extractLaaTransactionIdFromHeader(request);
 
-    if(StringUtils.isNotBlank(laaTransactionIdHeaderValue)){
+    if (StringUtils.isNotBlank(laaTransactionIdHeaderValue)) {
       log.debug("Adding the {} [{}] to the MDC", LAA_TRANSACTION_ID, laaTransactionIdHeaderValue);
       MDC.put(LAA_TRANSACTION_ID, laaTransactionIdHeaderValue);
 
     } else {
-      log.debug("Not adding the {} [{}] to the MDC, as it is blank", LAA_TRANSACTION_ID, laaTransactionIdHeaderValue);
+      log.debug("Not adding the {} [{}] to the MDC, as it is blank", LAA_TRANSACTION_ID,
+          laaTransactionIdHeaderValue);
     }
 
     chain.doFilter(request, response);
@@ -45,7 +39,7 @@ public class AddLaaTransactionIdToMDC implements Filter {
   private String extractLaaTransactionIdFromHeader(ServletRequest request) {
 
     if (request instanceof HttpServletRequest httpServletRequest) {
-      return  httpServletRequest.getHeader(LAA_TRANSACTION_ID);
+      return httpServletRequest.getHeader(LAA_TRANSACTION_ID);
     }
 
     return null;

--- a/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/filter/mdc/AfterFilterChainClearDownMDC.java
+++ b/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/filter/mdc/AfterFilterChainClearDownMDC.java
@@ -13,9 +13,6 @@ import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 @Slf4j
-@WebFilter("/*")
-@Component
-@Order
 public class AfterFilterChainClearDownMDC implements Filter {
     
     @Override

--- a/crime-commons-classes/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/crime-commons-classes/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+uk.gov.justice.laa.crime.config.FilterConfiguration

--- a/crime-commons-classes/src/test/java/uk/gov/justice/laa/crime/config/FilterConfigurationTest.java
+++ b/crime-commons-classes/src/test/java/uk/gov/justice/laa/crime/config/FilterConfigurationTest.java
@@ -1,0 +1,51 @@
+package uk.gov.justice.laa.crime.config;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import java.util.Collection;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.core.Ordered;
+import uk.gov.justice.laa.crime.filter.mdc.AddLaaTransactionIdToMDC;
+import uk.gov.justice.laa.crime.filter.mdc.AfterFilterChainClearDownMDC;
+
+class FilterConfigurationTest {
+
+  private FilterConfiguration filterConfiguration;
+
+  @BeforeEach
+  void setUp() {
+    filterConfiguration = new FilterConfiguration();
+  }
+
+  @Test
+  void addLaaTransactionIdToMDCFilter() {
+    FilterRegistrationBean<AddLaaTransactionIdToMDC> addLaaTransactionId = filterConfiguration.addLaaTransactionIdToMDCFilter();
+
+    Collection<String> actualUrlPatterns = addLaaTransactionId.getUrlPatterns();
+    assertAll(
+        () -> assertInstanceOf(AddLaaTransactionIdToMDC.class, addLaaTransactionId.getFilter()),
+        () -> assertThat(actualUrlPatterns, Matchers.hasSize(1)),
+        () -> assertThat(actualUrlPatterns, Matchers.contains("/*")),
+        () -> assertEquals(Ordered.HIGHEST_PRECEDENCE, addLaaTransactionId.getOrder())
+    );
+  }
+
+  @Test
+  void afterFilterChainClearDownMDCFilter() {
+    FilterRegistrationBean<AfterFilterChainClearDownMDC> clearDownMDC = filterConfiguration.afterFilterChainClearDownMDCFilter();
+
+    Collection<String> actualUrlPatterns = clearDownMDC.getUrlPatterns();
+    assertAll(
+        () -> assertInstanceOf(AfterFilterChainClearDownMDC.class, clearDownMDC.getFilter()),
+        () -> assertThat(actualUrlPatterns, Matchers.hasSize(1)),
+        () -> assertThat(actualUrlPatterns, Matchers.contains("/*")),
+        () -> assertEquals(Ordered.LOWEST_PRECEDENCE, clearDownMDC.getOrder())
+    );
+  }
+}


### PR DESCRIPTION
## What

Changes include:

- New `FilterConfiguration` with `@AutoConfiguration` annotation.
- Include the same new config in `org.springframework.boot.autoconfigure.AutoConfiguration.imports` in `crime-commons-classes` module.
- Remove unneeded annotations from Filters i.e. `@WebFilter("/*") @Component @Order(Ordered.HIGHEST_PRECEDENCE)` as this is now in the new `FilterConfiguration` class.

[Link to story - LASB-3326](https://dsdmoj.atlassian.net/browse/LASB-3326)

Allow the auto-discovery of filters.
