### PR TITLE
Declare all plugin version numbers in one place gradle.properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,4 @@ out/
 
 *.java-version
 .env
-gradle.properties
 *.DS_STORE

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 plugins {
-    id "com.javiersc.semver.project" version "0.5.0"
-    id "org.sonarqube" version "4.0.0.2929"
-    id "org.springframework.boot" version "3.1.5"
-    id 'io.spring.dependency-management' version '1.1.4'
-    id "io.github.gradle-nexus.publish-plugin" version "1.3.0"
+    id 'com.javiersc.semver.project' version "$semverVersion"
+    id 'org.sonarqube' version "$sonarQubeVersion"
+    id 'org.springframework.boot' version "$springframeworkBootVersion"
+    id 'io.spring.dependency-management' version "$springDependencyManagementVersion"
+    id 'io.github.gradle-nexus.publish-plugin' version "$publishPluginVersion"
 }
 
 group = "uk.gov.justice.service.laa-crime"

--- a/crime-commons-classes/build.gradle
+++ b/crime-commons-classes/build.gradle
@@ -1,10 +1,10 @@
 plugins {
-    id "com.javiersc.semver.project" version "0.5.0"
-    id "jacoco"
-    id "signing"
-    id "maven-publish"
-    id "org.springframework.boot" version "3.1.5"
-    id 'io.spring.dependency-management' version '1.1.4'
+    id 'com.javiersc.semver.project' version "$semverVersion"
+    id 'jacoco'
+    id 'signing'
+    id 'maven-publish'
+    id 'org.springframework.boot' version "$springframeworkBootVersion"
+    id 'io.spring.dependency-management' version "$springDependencyManagementVersion"
 }
 
 semver {

--- a/crime-commons-mod-schemas/build.gradle
+++ b/crime-commons-mod-schemas/build.gradle
@@ -1,9 +1,9 @@
 plugins {
-    id "com.javiersc.semver.project" version "0.5.0"
-    id "jacoco"
-    id "signing"
-    id "maven-publish"
-    id 'org.jsonschema2dataclass' version '6.0.0'
+    id 'com.javiersc.semver.project' version "$semverVersion"
+    id 'jacoco'
+    id 'signing'
+    id 'maven-publish'
+    id 'org.jsonschema2dataclass' version "$jsonSchema2DataVersion"
 }
 
 semver {

--- a/crime-commons-schemas/build.gradle
+++ b/crime-commons-schemas/build.gradle
@@ -1,8 +1,8 @@
 plugins {
-    id "com.javiersc.semver.project" version "0.5.0"
-    id "signing"
-    id "maven-publish"
-    id 'org.jsonschema2dataclass' version '6.0.0'
+    id 'com.javiersc.semver.project' version "$semverVersion"
+    id 'signing'
+    id 'maven-publish'
+    id 'org.jsonschema2dataclass' version "$jsonSchema2DataVersion"
 }
 
 semver {

--- a/crime-commons-spring-boot-starter-rest-client/build.gradle
+++ b/crime-commons-spring-boot-starter-rest-client/build.gradle
@@ -1,11 +1,11 @@
 plugins {
-    id "com.javiersc.semver.project" version "0.5.0"
-    id "jacoco"
-    id "signing"
-    id "maven-publish"
-    id 'com.github.johnrengelman.shadow' version '8.1.1'
-    id "org.springframework.boot" version "3.1.5"
-    id 'io.spring.dependency-management' version '1.1.4'
+    id 'com.javiersc.semver.project' version "$semverVersion"
+    id 'jacoco'
+    id 'signing'
+    id 'maven-publish'
+    id 'com.github.johnrengelman.shadow' version "$johnRengelmanShadowVersion"
+    id 'org.springframework.boot' version "$springframeworkBootVersion"
+    id 'io.spring.dependency-management' version "$springDependencyManagementVersion"
 }
 
 semver {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,10 @@
+# Plugin Dependency Versions
+semverVersion=0.5.0
+springframeworkBootVersion=3.1.5
+springDependencyManagementVersion=1.1.4
+jsonSchema2DataVersion=6.0.0
+johnRengelmanShadowVersion=8.1.1
+publishPluginVersion=1.3.0
+sonarQubeVersion=4.0.0.2929
+# Dependency Versions
+


### PR DESCRIPTION
## Declare all plugin version numbers in one place gradle.properties

Declare all plugin version numbers in one place, the `gradle.properties` thus reducing duplication.
Also provides a means to see and update all plugin versions in a single file, making version uplift maintenance less burdensome.

**TODO** as part of a future PR, do the same for non-plugin dependency versions.