### PR TITLE
LCAM 1529 Issue Deserialising Request Source When Calling Application Tracking Service

### DIFF
--- a/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/enums/orchestration/RequestSource.java
+++ b/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/enums/orchestration/RequestSource.java
@@ -1,5 +1,7 @@
 package uk.gov.justice.laa.crime.enums.orchestration;
 
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -14,5 +16,7 @@ public enum RequestSource {
     CROWN_COURT("crown_court"),
     CAPITAL_AND_EQUITY("capital_and_equity");
 
+    @JsonValue
+    @JsonPropertyDescription("The originating application for the request")
     private final String code;
 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/projects/LCAM/boards/881?selectedIssue=LCAM-1529)

- Added annotation to serialise requestSource enum using code so that correct value is passed when calling application tracking service.
