### PR TITLE
LCAM 1528 Hardship Details Not Being Set to Active on Database

### DIFF
--- a/crime-commons-mod-schemas/src/main/resources/schemas/hardship/maat-api/apiHardshipDetail.json
+++ b/crime-commons-mod-schemas/src/main/resources/schemas/hardship/maat-api/apiHardshipDetail.json
@@ -54,6 +54,10 @@
     "userCreated": {
       "type": "string",
       "description": "ID of the user creating the progress item"
+    },
+    "active": {
+      "type": "string",
+      "description": "Indicates if the detail is currently active"
     }
   },
   "required": ["frequency", "amount", "detailType", "timestamp"]


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/projects/LCAM/boards/881?selectedIssue=LCAM-1528)

- Added active variable to the apiHardshipDetail schema so that a value can be mapped to it form within the hardship service and then subsequently passed to maat-api to create a hardship review with active details.
