### PR TITLE
LCAM 1540 Solicitors Costs Not Record on Database When Creating Hardship

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ commands:
           steps:
             - run:
                 name: Publish snapshot release to Maven Central
-                command: ./gradlew pushSemverTag "-PisSnapshot=true" "-Psemver.stage=snapshot" "-Psemver.scope=minor" "-Psemver.tagPrefix=<< parameters.tagPrefix >>" :<< parameters.module >>:publishToSonatype closeAndReleaseSonatypeStagingRepository
+                command: ./gradlew pushSemverTag "-PisSnapshot=true" "-Psemver.stage=snapshot" "-Psemver.tagPrefix=<< parameters.tagPrefix >>" :<< parameters.module >>:publishToSonatype closeAndReleaseSonatypeStagingRepository
 
   authenticate_host:
     description: >

--- a/crime-commons-mod-schemas/src/main/resources/schemas/hardship/common/solicitorCosts.json
+++ b/crime-commons-mod-schemas/src/main/resources/schemas/hardship/common/solicitorCosts.json
@@ -26,5 +26,5 @@
       "description": "The total estimated cost (this is automatically calculated in MAAT)"
     }
   },
-  "required": ["rate", "hours", "vat", "disbursements", "estimatedTotal"]
+  "required": ["rate", "hours", "vat", "disbursements"]
 }

--- a/crime-commons-mod-schemas/src/main/resources/schemas/hardship/common/solicitorCosts.json
+++ b/crime-commons-mod-schemas/src/main/resources/schemas/hardship/common/solicitorCosts.json
@@ -23,7 +23,7 @@
     },
     "estimatedTotal": {
       "type": "number",
-      "description": "The total estimated cost (this is automatically calculated in MAAT)"
+      "description": "The total estimated cost"
     }
   },
   "required": ["rate", "hours", "vat", "disbursements"]


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/projects/LCAM/boards/881?selectedIssue=LCAM-1540)

- Removed the scope from the SNAPSHOT versioning as this was causing duplicate versioned SNAPSHOTs to be created following a patch release. Now the SNAPSHOT will be incremented using patch as a default. Not 100% foolproof but was a simple fix and should mean duplicates are less likely now.
- Removed estimated total from solicitors costs schema as it was causing bad request errors when calling the hardship service to create a mags hardship review with solicitors costs as the estimated total isn't calculated before the hardship service and is always null.
