### PR TITLE
Add pension amounts to ApiUpdateIncomeEvidenceRequest

### DIFF
--- a/crime-commons-mod-schemas/src/main/resources/schemas/evidence/apiUpdateIncomeEvidenceRequest.json
+++ b/crime-commons-mod-schemas/src/main/resources/schemas/evidence/apiUpdateIncomeEvidenceRequest.json
@@ -19,10 +19,18 @@
       "description": "Income evidence items associated with the applicant",
       "$ref": "common/apiIncomeEvidenceItems.json"
     },
+    "applicantPensionAmount": {
+      "type": "number",
+      "description": "Applicant pension amount"
+    },
     "partnerEvidenceItems": {
       "type": "object",
       "description": "Income evidence items associated with the partner",
       "$ref": "common/apiIncomeEvidenceItems.json"
+    },
+    "partnerPensionAmount": {
+      "type": "number",
+      "description": "Partner pension amount"
     },
     "metadata": {
       "type": "object",

--- a/crime-commons-mod-schemas/src/main/resources/schemas/meansassessment/common/apiIncomeEvidence.json
+++ b/crime-commons-mod-schemas/src/main/resources/schemas/meansassessment/common/apiIncomeEvidence.json
@@ -3,15 +3,15 @@
   "id": "apiIncomeEvidence.json",
   "type": "object",
   "title": "The Income Evidence schema",
-  "description": "Details of income evidence",
+  "description": "Information About an Income Evidence Item",
   "properties": {
     "id": {
       "type": "integer",
-      "description": "Evidence id"
+      "description": "The ID of the income evidence item associated with the financial assessment"
     },
     "dateReceived": {
       "type": "string",
-      "description": "Evidence received Date",
+      "description": "The date the evidence was received",
       "format": "date-time"
     },
     "dateModified": {
@@ -30,19 +30,19 @@
     },
     "mandatory": {
       "type": "string",
-      "description": "Mandatory flag"
+      "description": "Indicates whether the evidence is mandatory"
     },
     "applicantId": {
       "type": "integer",
-      "description": "Applicant associated with the income evidence"
+      "description": "The ID of the person associated with the income evidence (applicant or partner)"
     },
     "otherText": {
       "type": "string",
-      "description": "Other text"
+      "description": "The evidence description (required for certain evidence types)"
     },
     "adhoc": {
       "type": "string",
-      "description": "Adhoc"
+      "description": "Indicates who the other adhoc evidence is associated with (applicant or partner)"
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
This PR adds applicant and partner pension amounts to the _ApiUpdateIncomeEvidenceRequest_, for use by the Evidence Service to manage income evidence. It also adds better descriptions to the existing _ApiIncomeEvidence_ schema in the `means_assessment` package.

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1404)