### PR TITLE
Add applicationReceivedDate to ApiIncomeEvidenceMetadata schema

### DIFF
--- a/crime-commons-mod-schemas/src/main/resources/schemas/evidence/common/apiIncomeEvidenceMetadata.json
+++ b/crime-commons-mod-schemas/src/main/resources/schemas/evidence/common/apiIncomeEvidenceMetadata.json
@@ -5,6 +5,11 @@
   "title": "Income Evidence Metadata",
   "description": "MAAT specific metadata required to process income evidence",
   "properties": {
+    "applicationReceivedDate": {
+      "type": "string",
+      "description": "The date the application was received",
+      "format": "date"
+    },
     "evidencePending": {
       "type": "boolean",
       "description": "indicates whether there is still pending income evidence"
@@ -20,5 +25,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["userSession"]
+  "required": ["applicationReceivedDate", "userSession"]
 }


### PR DESCRIPTION
This PR adds the `applicationReceivedDate` field to the _ApiIncomeEvidenceMetadata_ schema, which is used when both creating and updating income evidence for an application as part of validation checks.

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1404)
