### PR TITLE
LCAM-1402|Tidy up the evidence request schemas

### DIFF
--- a/crime-commons-mod-schemas/src/main/resources/schemas/evidence/apiCreateIncomeEvidenceRequest.json
+++ b/crime-commons-mod-schemas/src/main/resources/schemas/evidence/apiCreateIncomeEvidenceRequest.json
@@ -10,10 +10,6 @@
       "description": "Magistrate Court Outcome",
       "existingJavaType": "uk.gov.justice.laa.crime.enums.MagCourtOutcome"
     },
-    "financialAssessmentId": {
-      "type": "integer",
-      "description": "The financial assessment ID the evidence relates to"
-    },
     "applicantDetails": {
       "type": "object",
       "description": "The applicants details",

--- a/crime-commons-mod-schemas/src/main/resources/schemas/evidence/apiUpdateIncomeEvidenceRequest.json
+++ b/crime-commons-mod-schemas/src/main/resources/schemas/evidence/apiUpdateIncomeEvidenceRequest.json
@@ -10,10 +10,6 @@
       "description": "Magistrate Court Outcome",
       "existingJavaType": "uk.gov.justice.laa.crime.enums.MagCourtOutcome"
     },
-    "financialAssessmentId": {
-      "type": "integer",
-      "description": "The financial assessment ID the evidence relates to"
-    },
     "applicantEvidenceItems": {
       "type": "object",
       "description": "Income evidence items associated with the applicant",


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1402)

Removed financial assessment id from the create and update income evidence request schemas.
