### PR TITLE
LCAM-1609|Moving TraceIdHandler to common classes for reuse

### DIFF
--- a/crime-commons-classes/build.gradle
+++ b/crime-commons-classes/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     implementation group: 'commons-io', name: 'commons-io', version: versions.commonsioVersion
 
     implementation "org.apache.commons:commons-lang3"
+    implementation 'io.micrometer:micrometer-tracing'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'

--- a/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/dto/ErrorDTO.java
+++ b/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/dto/ErrorDTO.java
@@ -1,10 +1,14 @@
 package uk.gov.justice.laa.crime.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.NoArgsConstructor;
 import lombok.Value;
 
 @Value
 @Builder
+@NoArgsConstructor(force = true)
+@AllArgsConstructor
 public class ErrorDTO {
     String traceId;
     String code;

--- a/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/tracing/TraceIdHandler.java
+++ b/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/tracing/TraceIdHandler.java
@@ -1,0 +1,27 @@
+package uk.gov.justice.laa.crime.tracing;
+
+import io.micrometer.tracing.CurrentTraceContext;
+import io.micrometer.tracing.TraceContext;
+import io.micrometer.tracing.Tracer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+/**
+ * Helper class for REST API Exception Handler to add the traceId in Error Response.
+ */
+@Component
+@RequiredArgsConstructor
+public class TraceIdHandler {
+
+    private final Tracer tracer;
+
+    public String getTraceId() {
+        return Optional.of(tracer).
+                map(Tracer::currentTraceContext).
+                map(CurrentTraceContext::context).
+                map(TraceContext::traceId).
+                orElse("");
+    }
+}

--- a/crime-commons-classes/src/test/java/uk/gov/justice/laa/crime/tracing/TraceIdHandlerTest.java
+++ b/crime-commons-classes/src/test/java/uk/gov/justice/laa/crime/tracing/TraceIdHandlerTest.java
@@ -1,0 +1,52 @@
+package uk.gov.justice.laa.crime.tracing;
+
+import io.micrometer.tracing.CurrentTraceContext;
+import io.micrometer.tracing.TraceContext;
+import io.micrometer.tracing.Tracer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
+class TraceIdHandlerTest {
+
+    @InjectMocks
+    private TraceIdHandler traceIdHandler;
+
+    @Mock
+    private Tracer tracer;
+
+    @Mock
+    private CurrentTraceContext currentTraceContext;
+
+    @Mock
+    private TraceContext traceContext;
+
+    @Test
+    void whenCurrentTraceContextIsNull_thenTraceIdIsBlank() {
+        when(tracer.currentTraceContext()).thenReturn(null);
+        assertTrue(traceIdHandler.getTraceId().isBlank());
+    }
+
+    @Test
+    void whenTraceContextIsNull_thenTraceIdIsBlank() {
+        when(tracer.currentTraceContext()).thenReturn(currentTraceContext);
+        when(currentTraceContext.context()).thenReturn(null);
+        assertTrue(traceIdHandler.getTraceId().isBlank());
+    }
+
+    @Test
+    void whenTraceContextIsNotNull_thenReturnValidTraceId() {
+        when(tracer.currentTraceContext()).thenReturn(currentTraceContext);
+        when(currentTraceContext.context()).thenReturn(traceContext);
+        when(traceContext.traceId()).thenReturn("652d43b680a77a2af057d826df7a0c6c");
+        assertFalse(traceIdHandler.getTraceId().isBlank());
+    }
+}


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1609)

Moving TraceIdHandler to common classes so that this can be used in the micro-services during exception handling.
Updated ErrorDTO to allow deserialisation during exception handling.
