### PR TITLE
LCAM-1628-refactor-proceeding-schema

### DIFF
--- a/crime-commons-mod-schemas/src/main/resources/schemas/proceeding/request/apiProcessRepOrderRequest.json
+++ b/crime-commons-mod-schemas/src/main/resources/schemas/proceeding/request/apiProcessRepOrderRequest.json
@@ -61,5 +61,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["repId", "caseType", "dateReceived", "crownCourtSummary", "iojAppeal", "financialAssessment"]
+  "required": ["repId", "caseType", "dateReceived", "crownCourtSummary", "iojAppeal"]
 }

--- a/crime-commons-mod-schemas/src/main/resources/schemas/proceeding/request/apiUpdateApplicationRequest.json
+++ b/crime-commons-mod-schemas/src/main/resources/schemas/proceeding/request/apiUpdateApplicationRequest.json
@@ -21,27 +21,6 @@
       "type": "object",
       "description": "The current users session",
       "$ref": "../../common/apiUserSession.json"
-    },
-    "capitalEvidence": {
-      "type": "array",
-      "description": "List of Capital Evidence",
-      "items": {
-        "$ref": "../common/apiCapitalEvidence.json"
-      }
-    },
-    "incomeEvidenceReceivedDate": {
-      "type": "string",
-      "description": "Income evidence Received Date",
-      "format": "date-time"
-    },
-    "capitalEvidenceReceivedDate": {
-      "type": "string",
-      "description": "Capital evidence Received Date",
-      "format": "date-time"
-    },
-    "emstCode": {
-      "type": "string",
-      "description": "Emp status code"
     }
   },
   "extends": {

--- a/crime-commons-mod-schemas/src/main/resources/schemas/proceeding/request/apiUpdateCrownCourtRequest.json
+++ b/crime-commons-mod-schemas/src/main/resources/schemas/proceeding/request/apiUpdateCrownCourtRequest.json
@@ -5,63 +5,9 @@
   "title": "Update Crown Court Request",
   "description": "Data contract for update crown court application request",
   "properties": {
-    "repId": {
-      "type": "integer",
-      "description": "MAAT / Rep Id"
-    },
-    "caseType": {
-      "type": "object",
-      "description": "The case type",
-      "existingJavaType": "uk.gov.justice.laa.crime.enums.CaseType"
-    },
-    "magCourtOutcome": {
-      "type": "object",
-      "description": "Magistrate Court Outcome",
-      "existingJavaType": "uk.gov.justice.laa.crime.enums.MagCourtOutcome"
-    },
-    "decisionReason": {
-      "type": "object",
-      "description": "Decision Reason",
-      "existingJavaType": "uk.gov.justice.laa.crime.enums.DecisionReason"
-    },
-    "decisionDate": {
+    "emstCode": {
       "type": "string",
-      "description": "Decision Date",
-      "format": "date-time"
-    },
-    "committalDate": {
-      "type": "string",
-      "description": "Committal Date",
-      "format": "date-time"
-    },
-    "dateReceived": {
-      "type": "string",
-      "description": "Date Received",
-      "format": "date-time"
-    },
-    "applicantHistoryId": {
-      "type": "integer",
-      "description": "The applicant history Id"
-    },
-    "crownRepId": {
-      "type": "integer",
-      "description": "The Crown Rep ID"
-    },
-    "isImprisoned": {
-      "type": "boolean",
-      "description": "Indicate whether the applicant is imprisoned"
-    },
-    "userSession": {
-      "type": "object",
-      "description": "The current users session",
-      "$ref": "../../common/apiUserSession.json"
-    },
-    "capitalEvidence": {
-      "type": "array",
-      "description": "List of Capital Evidence",
-      "items": {
-        "$ref": "../common/apiCapitalEvidence.json"
-      }
+      "description": "Emp status code"
     },
     "incomeEvidenceReceivedDate": {
       "type": "string",
@@ -73,31 +19,16 @@
       "description": "Capital evidence Received Date",
       "format": "date-time"
     },
-    "emstCode": {
-      "type": "string",
-      "description": "Emp status code"
+    "capitalEvidence": {
+      "type": "array",
+      "description": "List of Capital Evidence",
+      "items": {
+        "$ref": "../common/apiCapitalEvidence.json"
+      }
     },
-    "crownCourtSummary": {
-      "type": "object",
-      "description": "Crown court overview",
-      "$ref": "../common/apiCrownCourtSummary.json"
-    },
-    "iojAppeal": {
-      "type": "object",
-      "description": "IOJ Appeal",
-      "$ref": "../common/apiIOJSummary.json"
-    },
-    "financialAssessment": {
-      "type": "object",
-      "description": "Financial assessment",
-      "$ref": "../common/apiFinancialAssessment.json"
-    },
-    "passportAssessment": {
-      "type": "object",
-      "description": "passport assessment",
-      "$ref": "../common/apiPassportAssessment.json"
+    "extends": {
+      "$ref": "apiUpdateApplicationRequest.json"
     }
   },
-  "additionalProperties": false,
-  "required": ["repId", "caseType", "dateReceived", "isImprisoned", "userSession", "applicantHistoryId", "crownCourtSummary", "iojAppeal"]
+  "additionalProperties": false
 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1628)

- apiUpdateCrownCourtRequest schema should extend updateApplicationRequest

- Move the following fields from apiUpdateApplicationRequest to apiUpdateCrownCourtRequest:
    emstCode
    incomeEvidenceReceivedDate
    capitalEvidenceReceivedDate
    capitalEvidence

- Financial assessment fields should be made nullable 
