### PR TITLE
LCAM-1660|Tidy up the Evidence response schemas

### DIFF
--- a/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/util/SortUtils.java
+++ b/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/util/SortUtils.java
@@ -10,17 +10,17 @@ import java.util.function.Function;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class SortUtils {
 
-    public static <T, U extends Comparable> void sortListWithComparing(List<T> t, Function<T, U> compFunction, Function<T, U> thenCompFunc, Comparator<U> comparator) {
+    public static <T, U extends Comparable<? super U>> void sortListWithComparing(List<T> t, Function<T, U> compFunction, Function<T, U> thenCompFunc, Comparator<U> comparator) {
         if (t != null) {
             t.sort(Comparator.comparing(compFunction, comparator).thenComparing(thenCompFunc, comparator));
         }
     }
 
-    public static <U extends Comparable> Comparator<U> getComparator() {
+    public static <U extends Comparable<? super U>> Comparator<U> getComparator() {
         return Comparator.naturalOrder();
     }
 
-    public static <U extends Comparable> Comparator<U> getReverseComparator() {
+    public static <U extends Comparable<? super U>> Comparator<U> getReverseComparator() {
         return Comparator.reverseOrder();
     }
 }

--- a/crime-commons-mod-schemas/src/main/resources/schemas/evidence/apiCreateIncomeEvidenceResponse.json
+++ b/crime-commons-mod-schemas/src/main/resources/schemas/evidence/apiCreateIncomeEvidenceResponse.json
@@ -16,6 +16,5 @@
       "$ref": "common/apiIncomeEvidenceItems.json"
     }
   },
-  "additionalProperties": false,
-  "required": ["applicantDetails", "partnerDetails"]
+  "additionalProperties": false
 }

--- a/crime-commons-mod-schemas/src/main/resources/schemas/evidence/apiUpdateIncomeEvidenceResponse.json
+++ b/crime-commons-mod-schemas/src/main/resources/schemas/evidence/apiUpdateIncomeEvidenceResponse.json
@@ -5,16 +5,6 @@
   "title": "Update Income Evidence Response",
   "description": "Data Contract for Update Income Evidence Response",
   "properties": {
-    "applicantEvidenceItems": {
-      "type": "object",
-      "description": "Income evidence items associated with the applicant",
-      "$ref": "common/apiIncomeEvidenceItems.json"
-    },
-    "partnerEvidenceItems": {
-      "type": "object",
-      "description": "Income evidence items associated with the partner",
-      "$ref": "common/apiIncomeEvidenceItems.json"
-    },
     "dueDate": {
       "type": "string",
       "format": "date",
@@ -26,6 +16,8 @@
       "description": "The date that all of the evidence was received"
     }
   },
-  "additionalProperties": false,
-  "required": ["applicantEvidenceItems", "partnerEvidenceItems", "dueDate"]
+  "extends": {
+    "$ref": "apiCreateIncomeEvidenceResponse.json"
+  },
+  "additionalProperties": false
 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1660)

Tidied up the Evidence response schemas to remove duplication and fix the required field section.

Also fixed the method declaration in the SortUitls class.
