### PR TITLE
LCAM-1688|Add the uplift fields to the UpdateAssessment schema

### DIFF
--- a/crime-commons-mod-schemas/src/main/resources/schemas/meansassessment/maatapi/maatApiAssessmentResponse.json
+++ b/crime-commons-mod-schemas/src/main/resources/schemas/meansassessment/maatapi/maatApiAssessmentResponse.json
@@ -80,6 +80,11 @@
       "format": "date-time",
       "description": "Income Evidence Due Date"
     },
+    "evidenceReceivedDate": {
+      "type": "string",
+      "format": "date-time",
+      "description": "The date that all of the income evidence was received"
+    },
     "incomeUpliftRemoveDate": {
       "type": "string",
       "format": "date-time",

--- a/crime-commons-mod-schemas/src/main/resources/schemas/meansassessment/maatapi/maatApiUpdateAssessment.json
+++ b/crime-commons-mod-schemas/src/main/resources/schemas/meansassessment/maatapi/maatApiUpdateAssessment.json
@@ -61,6 +61,21 @@
       "items": {
         "$ref": "financialAssessmentIncomeEvidence.json"
       }
+    },
+    "incomeUpliftApplyDate": {
+      "type": "string",
+      "description": "The current uplift applied date",
+      "format": "date-time"
+    },
+    "incomeUpliftRemoveDate": {
+      "type": "string",
+      "description": "The current uplift removed date",
+      "format": "date-time"
+    },
+    "evidenceReceivedDate": {
+      "type": "string",
+      "description": "The date that all of the income evidence was received",
+      "format": "date-time"
     }
   },
   "extends": {


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1688)

Enhanced the MAAT API UpdateAssessment schema to include the following fields that can be updated as part of the update_income_evidence flow:
incomeUpliftApplyDate - Uplift Applied Date
incomeUpliftRemoveDate - Uplift Removed Date
evidenceReceivedDate - All income evidence received date

Also updated the MAAT API Assessment Response schema to add the missing field:
evidenceReceivedDate - Income Evidence Received Date
