### PR TITLE
LCAM-1728-remove-mandatory-filed

### DIFF
--- a/crime-commons-mod-schemas/src/main/resources/schemas/evidence/apiUpdateIncomeEvidenceRequest.json
+++ b/crime-commons-mod-schemas/src/main/resources/schemas/evidence/apiUpdateIncomeEvidenceRequest.json
@@ -70,5 +70,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["magCourtOutcome", "metadata", "evidenceDueDate", "financialAssessmentId"]
+  "required": ["magCourtOutcome", "metadata", "financialAssessmentId"]
 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1728)

EvidenceDueDate is not mandatory when we update income evidence flow. 