### PR TITLE
LASB-3900 [CAA & MAAT API] Adding field passport_review_type & means_review_type of the means_test to the API result

### DIFF
--- a/crime-commons-schemas/src/main/resources/schemas/atis/crime_application_result.json
+++ b/crime-commons-schemas/src/main/resources/schemas/atis/crime_application_result.json
@@ -100,10 +100,15 @@
       "nullable": true,
       "description": "Passported Created Date"
     },
-    "review_type": {
+    "passport_review_type": {
       "type": "string",
       "nullable": true,
-      "description": "Assessment Review Type"
+      "description": "Passported Review Type"
+    },
+    "means_review_type": {
+      "type": "string",
+      "nullable": true,
+      "description": "Means Assessment Review Type"
     }
   }
 }


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-3900)

Describe what you did and why.

As part of the enhancement to the LAA Crime Applications Adapter, we need to include the review_type field from the means_test in the API response. Added the review type field in the response
