### PR TITLE
[LCAM-1745] Update required flag in apiDetermineMagsRepDecisionRequest.json

### DIFF
--- a/crime-commons-mod-schemas/src/main/resources/schemas/proceeding/request/apiDetermineMagsRepDecisionRequest.json
+++ b/crime-commons-mod-schemas/src/main/resources/schemas/proceeding/request/apiDetermineMagsRepDecisionRequest.json
@@ -35,5 +35,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["repId", "caseType", "iojAppeal", "financialAssessment", "passportAssessment"]
+  "required": ["repId", "caseType", "iojAppeal"]
 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1745)

Removed the required flag on 'financialAssessment' and 'passportAssessment' in 'apiDetermineMagsRepDecisionRequest.json'. These fields should not be required for this request type. 
