### PR TITLE
LASB-3908 [CAA & MAAT API] Adding field Means & Passport Work Reasons of the means_test to the API result

### DIFF
--- a/crime-commons-schemas/src/main/resources/schemas/atis/crime_application_result.json
+++ b/crime-commons-schemas/src/main/resources/schemas/atis/crime_application_result.json
@@ -109,6 +109,16 @@
       "type": "string",
       "nullable": true,
       "description": "Means Assessment Review Type"
+    },
+    "passport_work_reason": {
+      "type": "string",
+      "nullable": true,
+      "description": "Passported New Work Reason Code"
+    },
+    "means_work_reason": {
+      "type": "string",
+      "nullable": true,
+      "description": "Means Assessment New Work Reason Code"
     }
   }
 }


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-3908)

Describe what you did and why.

As part of the enhancement to the LAA Crime Applications Adapter, we need to include the Work Reason Code field from the means_test in the API response. Added the meansWorkReason & passportWorkReason field in the response
