### PR TITLE
Upgrade Spring Boot to 3.4.4

### DIFF
--- a/crime-commons-samples/build.gradle
+++ b/crime-commons-samples/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id "org.springframework.boot" version "3.4.4"
-    id "io.spring.dependency-management" version "1.1.7"
+    id "org.springframework.boot" version "$springframeworkBootVersion"
+    id "io.spring.dependency-management" version "$springDependencyManagementVersion"
 }
 dependencies {
 

--- a/crime-commons-samples/build.gradle
+++ b/crime-commons-samples/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.springframework.boot" version "3.4.0"
+    id "org.springframework.boot" version "3.4.4"
     id "io.spring.dependency-management" version "1.1.7"
 }
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Plugin Dependency Versions
 semverVersion=0.7.1
-springframeworkBootVersion=3.4.0
+springframeworkBootVersion=3.4.4
 springDependencyManagementVersion=1.1.7
 jsonSchema2DataVersion=6.0.0
 johnRengelmanShadowVersion=8.1.1


### PR DESCRIPTION
This PR upgrades Spring Boot to version `3.4.4`, which addresses downstream dependencies affected by a [recently published security vulnerability](https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-9486467).

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1792)
