### PR TITLE
LCAM-1820

### DIFF
--- a/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/enums/CaseType.java
+++ b/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/enums/CaseType.java
@@ -19,7 +19,7 @@ import java.util.Set;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public enum CaseType {
     INDICTABLE("INDICTABLE", "Indictable", Boolean.TRUE),
-    SUMMARY_ONLY("SUMMARY ONLY", "Summary-only", Boolean.TRUE),
+    SUMMARY_ONLY("SUMMARY ONLY", "Summary-Only", Boolean.TRUE),
     CC_ALREADY("CC ALREADY","Trial already in Crown Court", Boolean.TRUE),
     APPEAL_CC("APPEAL CC","Appeal to Crown Court", Boolean.FALSE),
     COMMITAL("COMMITAL","Committal for Sentence", Boolean.TRUE),


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1820)

Part of reorganisation test changes, the case type are driven from Enum rather than .json file. 
Currently assessment fails for summary only case because  of miss match. 

