### PR TITLE
Add schemas for IoJ Appeals

### DIFF
--- a/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/enums/IojAppealAssessor.java
+++ b/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/enums/IojAppealAssessor.java
@@ -1,0 +1,6 @@
+package uk.gov.justice.laa.crime.enums;
+
+public enum IojAppealAssessor {
+    CASEWORKER,
+    JUDGE
+}

--- a/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/enums/IojAppealDecision.java
+++ b/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/enums/IojAppealDecision.java
@@ -1,0 +1,6 @@
+package uk.gov.justice.laa.crime.enums;
+
+public enum IojAppealDecision {
+    PASS,
+    FAIL
+}

--- a/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/enums/IojAppealDecisionReason.java
+++ b/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/enums/IojAppealDecisionReason.java
@@ -1,0 +1,38 @@
+package uk.gov.justice.laa.crime.enums;
+
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.stream.Stream;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+
+@Getter
+@AllArgsConstructor
+public enum IojAppealDecisionReason {
+
+    LOSS_OF_LIBERTY("LOSLIBTY", "Loss of liberty"),
+    SUSPENDED_SENTENCE("SUSPSENT", "Subject to a suspended sentence"),
+    LOSS_OF_LIVELIHOOD("LOSSLIVEHD", "Loss of livelihood"),
+    DAMAGE_TO_REPUTATION("SEDAMTOREP", "Serious damage to reputation"),
+    QUESTION_OF_LAW ("SUBQUELAW", "Substantial question of law"),
+    UNDERSTAND_PROCEEDINGS("NOTUNDPROC", "Would not understand the proceedings"),
+    WITNESS_TRACE  ("WITTRACE", "Witnesses to be traced"),
+    SKILL_EXAM ("SKILLEXAM", "Skillful exam of prosecution witness"),
+    INTERESTS_PERSON("INTANOPERS", "In the interests of another person"),
+    OTHER("OTHER", "Other");
+
+    @JsonPropertyDescription("IoJ decision reason code")
+    @JsonValue
+    private final String code;
+    private final String description;
+
+    public static IojAppealDecisionReason getFrom(String code) {
+        if (StringUtils.isBlank(code)) { return null; }
+
+        return Stream.of(IojAppealDecisionReason.values())
+            .filter(reason -> reason.code.equals(code))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException(String.format("IoJ appeal decision reason code: %s does not exist.", code)));
+    }
+}

--- a/crime-commons-mod-schemas/src/main/resources/schemas/ioj/apiGetIojAppealResponse.json
+++ b/crime-commons-mod-schemas/src/main/resources/schemas/ioj/apiGetIojAppealResponse.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "apiGetIojAppealResponse.json",
+  "type": "object",
+  "title": "Get IoJ Appeal response",
+  "description": "Data contract for the response to get an IoJ Appeal",
+  "properties": {
+    "appealId": {
+      "type": "integer",
+      "description": "The ID of the appeal"
+    }
+  },
+  "extends": {
+    "$ref": "common/iojAppeal.json"
+  },
+  "additionalProperties": false,
+  "required": ["appealId"]
+}

--- a/crime-commons-mod-schemas/src/main/resources/schemas/ioj/apiPerformIojAppealRequest.json
+++ b/crime-commons-mod-schemas/src/main/resources/schemas/ioj/apiPerformIojAppealRequest.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "apiPerformIojAppealRequest.json",
+  "type": "object",
+  "title": "IoJ Appeal request",
+  "description": "Data contract for creating or updating an IoJ Appeal",
+  "properties": {
+    "iojAppeal": {
+      "type": "object",
+      "$ref": "common/iojAppeal.json",
+      "description": "The details of the IoJ Appeal"
+    },
+    "iojAppealMetadata": {
+      "type": "object",
+      "$ref": "common/iojAppealMetadata.json",
+      "description": "The metadata for the IoJ Appeal"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["iojAppeal", "iojAppealMetadata"]
+}

--- a/crime-commons-mod-schemas/src/main/resources/schemas/ioj/apiPerformIojAppealResponse.json
+++ b/crime-commons-mod-schemas/src/main/resources/schemas/ioj/apiPerformIojAppealResponse.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "apiPerformIojAppealResponse.json",
+  "type": "object",
+  "title": "Perform IoJ Appeal response",
+  "description": "Data contract for the response to create or update an IoJ Appeal",
+  "properties": {
+    "appealId": {
+      "type": "integer",
+      "description": "The ID of the appeal"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["appealId"]
+}

--- a/crime-commons-mod-schemas/src/main/resources/schemas/ioj/common/iojAppeal.json
+++ b/crime-commons-mod-schemas/src/main/resources/schemas/ioj/common/iojAppeal.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "iojAppeal.json",
+  "type": "object",
+  "title": "IoJ Appeal",
+  "description": "IoJ Appeal Data",
+  "properties": {
+    "receiptDate": {
+      "type": "string",
+      "description": "The date when the appeal was received",
+      "format": "date-time"
+    },
+    "appealReason": {
+      "description": "The reason for creating the appeal",
+      "type": "object",
+      "existingJavaType": "uk.gov.justice.laa.crime.enums.NewWorkReason"
+    },
+    "appealAssessor": {
+      "description": "The authority making the decision on the appeal (caseworker or judge)",
+      "type": "object",
+      "existingJavaType": "uk.gov.justice.laa.crime.enums.IojAppealAssessor"
+    },
+    "appealDecision": {
+      "description": "The decision made on the appeal",
+      "type": "object",
+      "existingJavaType": "uk.gov.justice.laa.crime.enums.IojAppealDecision"
+    },
+    "decisionReason": {
+      "description": "The reason supporting the decision made on the appeal",
+      "type": "object",
+      "existingJavaType": "uk.gov.justice.laa.crime.enums.IojAppealDecisionReason"
+    },
+    "notes": {
+      "type": "string",
+      "description": "Notes relating to the appeal"
+    },
+    "decisionDate": {
+      "type": "string",
+      "description": "The date when the decision for the appeal was made",
+      "format": "date-time"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["receiptDate", "appealReason", "appealAssessor", "appealDecision", "decisionReason", "decisionDate"]
+}

--- a/crime-commons-mod-schemas/src/main/resources/schemas/ioj/common/iojAppealMetadata.json
+++ b/crime-commons-mod-schemas/src/main/resources/schemas/ioj/common/iojAppealMetadata.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "iojAppealMetadata.json",
+  "type": "object",
+  "title": "IoJ Appeal Metadata",
+  "description": "IoJ Appeal metadata",
+  "properties": {
+    "repId": {
+      "type": "integer",
+      "description": "The Representation Order ID / MAAT ID that the appeal relates to"
+    },
+    "caseManagementUnitId": {
+      "type": "integer",
+      "description": "The Case Management Unit ID, based on current user and Local Justice Area"
+    },
+    "appealStatus": {
+      "description": "The status of the appeal in MAAT",
+      "type": "object",
+      "existingJavaType": "uk.gov.justice.laa.crime.enums.CurrentStatus"
+    },
+    "userSession": {
+      "type": "object",
+      "description": "The current user session",
+      "$ref": "../../common/apiUserSession.json"
+    },
+    "appealId": {
+      "type": "integer",
+      "description": "The ID of the appeal (required for updates)"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["repId", "cmuId", "appealStatus", "userSession"]
+}


### PR DESCRIPTION
This PR adds schemas for creating, updating and getting an IoJ Appeal. It mostly captures the existing data that users are required to enter as part of creating an appeal through MAAT, but changes this somewhat to more clearly define who is deciding on the appeal (caseworker of judge) rather than duplicating data through the existing appeal set-up result.

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1817)

[Schema design write-up](https://dsdmoj.atlassian.net/wiki/spaces/ASLST/pages/5656117904/Interest+of+Justice+-+Schema+Endpoint+designs)
