### PR TITLE
LASB 4183 Upgrade to Java 21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ executors:
   openjdk-executor:
     resource_class: medium
     docker:
-      - image: cimg/openjdk:17.0.6
+      - image: cimg/openjdk:21.0.6
 
 # ------------------
 # COMMANDS

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: 17
+        java-version: 21
 
     - name: Checkout repository
       uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ communicating with other services and also provides several related utility clas
 
 ### Pre-requisites
 
-- JDK 17
+- JDK 21
 - Spring Boot 3.0.4
 
 Install dependencies and build modules with Gradle:

--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,8 @@ subprojects {
     // Disable warnings for missing JavaDoc
     javadoc.options.addStringOption('Xdoclint:none', '-quiet')
 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 
     group = "uk.gov.justice.service.laa-crime"
 

--- a/crime-commons-samples/Dockerfile
+++ b/crime-commons-samples/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:17-alpine
+FROM amazoncorretto:21-alpine
 RUN mkdir -p /opt/samples/
 WORKDIR /opt/samples/
 COPY ./build/libs/samples.jar /opt/samples/app.jar

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,0 @@
-jdk:
-  - openjdk17
-before_install:
-  - sdk install java 17.0.3-tem
-  - sdk use java 17.0.3-tem


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/c/projects/LASB/boards/454?selectedIssue=LASB-4183)

- Upgraded to Java 21 for builds, pipelines and PR tasks (excluding crime-commons-schemas which I left at Java 8 as we've not upgraded the version of Java in MAAT yet).
- Removed redundant jitpack config.
