### PR TITLE
LCAM-2023

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ project(":crime-commons-classes") {
             property "sonar.coverage.jacoco.xmlReportPaths",
                     "${project(":crime-commons-classes").buildDir}/reports/jacoco/test/jacocoTestReport.xml"
             property "sonar.exclusions", "**/exception/**.java, **/enums/**.java"
-            property "sonar.coverage.exclusions", "**/exception/**.java, **/enums/**.java"
+            property "sonar.coverage.exclusions", "**/exception/**.java, **/enums/**.java, **/error/**"
         }
     }
 }

--- a/crime-commons-classes/build.gradle
+++ b/crime-commons-classes/build.gradle
@@ -78,9 +78,9 @@ publishing {
                 }
                 developers {
                     developer {
-                        id = "Muthu"
-                        name = "Muthu Subramanian"
-                        email = "muthu.subramanian@digital.justice.gov.uk"
+                        id = "mhowell494"
+                        name = "Matthew Howell"
+                        email = "matthew.howell@digital.justice.gov.uk"
                     }
                 }
                 scm {

--- a/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/error/ProblemDetailError.java
+++ b/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/error/ProblemDetailError.java
@@ -1,0 +1,25 @@
+package uk.gov.justice.laa.crime.error;
+
+public enum ProblemDetailError {
+    DB_ERROR("Request violates a data constraint"),
+    VALIDATION_FAILURE("Validation failure"),
+    OBJECT_NOT_FOUND("Resource not found"),
+    APPLICATION_ERROR("Unexpected error"),
+    METHOD_NOT_ALLOWED("HTTP method not allowed"),
+    UNSUPPORTED_MEDIA_TYPE("Unsupported media type"),
+    BAD_REQUEST("Invalid request");
+
+    private final String defaultDetail;
+
+    ProblemDetailError(String defaultDetail) {
+        this.defaultDetail = defaultDetail;
+    }
+
+    public String code() {
+        return name();
+    }
+
+    public String defaultDetail() {
+        return defaultDetail;
+    }
+}

--- a/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/util/ProblemDetailUtil.java
+++ b/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/util/ProblemDetailUtil.java
@@ -16,6 +16,7 @@ import org.springframework.http.ProblemDetail;
 import org.springframework.http.converter.json.ProblemDetailJacksonMixin;
 import uk.gov.justice.laa.crime.error.ErrorExtension;
 import uk.gov.justice.laa.crime.error.ErrorMessage;
+import uk.gov.justice.laa.crime.error.ProblemDetailError;
 
 /**
  * Utility Class for single source for handling errors being passed via the ProblemDetail class.
@@ -97,6 +98,29 @@ public final class ProblemDetailUtil {
             String detail, String instance, ErrorExtension extension) {
         return buildProblemDetail(status, title, URI.create(type), detail, URI.create(instance),
                 extension);
+    }
+
+
+    /**
+     * Builds a {@link ProblemDetail} using the supplied status and {@link ProblemDetailError}.
+     *
+     * <p>The {@code error} provides the default {@code detail} value for the {@link ProblemDetail}
+     * and the error {@code code} for the attached {@link ErrorExtension}.
+     *
+     * @param status   the HTTP status, as defined by
+     *                 <a href="https://www.rfc-editor.org/rfc/rfc9457#name-status">RFC-9457</a>
+     * @param error    the error type containing the code and default detail
+     * @param traceId  the trace identifier for the request
+     * @param messages the error messages to include in the extension
+     * @return a populated {@link ProblemDetail} instance
+     */
+    public static ProblemDetail buildProblemDetail(
+            HttpStatusCode status,
+            ProblemDetailError error,
+            String traceId,
+            List<ErrorMessage> messages) {
+        ErrorExtension extension = buildErrorExtension(error.code(), traceId, messages);
+        return buildProblemDetail(status, error.defaultDetail(), extension);
     }
 
     /**

--- a/crime-commons-classes/src/test/java/uk/gov/justice/laa/crime/util/ProblemDetailUtilTest.java
+++ b/crime-commons-classes/src/test/java/uk/gov/justice/laa/crime/util/ProblemDetailUtilTest.java
@@ -21,6 +21,7 @@ import org.springframework.http.ProblemDetail;
 import org.springframework.http.converter.json.ProblemDetailJacksonMixin;
 import uk.gov.justice.laa.crime.error.ErrorExtension;
 import uk.gov.justice.laa.crime.error.ErrorMessage;
+import uk.gov.justice.laa.crime.error.ProblemDetailError;
 
 class ProblemDetailUtilTest {
 
@@ -110,6 +111,26 @@ class ProblemDetailUtilTest {
     void givenNoProblemDetail_whenNullPassedIn_thenEmptyListReturned() {
         List<String> returnedErrors = ProblemDetailUtil.getErrorDetailsWithDefault(null);
         assertThat(returnedErrors).isEqualTo(List.of());
+    }
+
+    @Test
+    void givenProblemDetailError_whenBuildProblemDetailCalled_thenUsesDefaultDetailAndCode() {
+        List<ErrorMessage> messages = List.of(new ErrorMessage("field", "message"));
+
+        ProblemDetail problemDetail = ProblemDetailUtil.buildProblemDetail(
+                HttpStatus.BAD_REQUEST,
+                ProblemDetailError.VALIDATION_FAILURE,
+                "trace-123",
+                messages);
+
+        assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(problemDetail.getDetail()).isEqualTo(ProblemDetailError.VALIDATION_FAILURE.defaultDetail());
+
+        assertThat(ProblemDetailUtil.getErrorExtension(problemDetail))
+                .contains(new ErrorExtension(
+                        ProblemDetailError.VALIDATION_FAILURE.code(),
+                        "trace-123",
+                        messages));
     }
 
     @Test

--- a/crime-commons-classes/src/test/java/uk/gov/justice/laa/crime/util/ProblemDetailUtilTest.java
+++ b/crime-commons-classes/src/test/java/uk/gov/justice/laa/crime/util/ProblemDetailUtilTest.java
@@ -166,7 +166,6 @@ class ProblemDetailUtilTest {
         ErrorExtension extension = createErrorExtension(2);
         ProblemDetail problemDetail = ProblemDetailUtil.buildProblemDetail(HttpStatus.BAD_REQUEST,
                 HttpStatus.BAD_REQUEST.getReasonPhrase(), extension);
-        assertThat(problemDetail).isNotNull();
         assertThat(ProblemDetailUtil.getErrorExtension(problemDetail))
                 .contains(extension);
     }

--- a/crime-commons-classes/src/test/java/uk/gov/justice/laa/crime/util/ProblemDetailUtilTest.java
+++ b/crime-commons-classes/src/test/java/uk/gov/justice/laa/crime/util/ProblemDetailUtilTest.java
@@ -1,15 +1,5 @@
 package uk.gov.justice.laa.crime.util;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.IntStream;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -22,6 +12,15 @@ import org.springframework.http.converter.json.ProblemDetailJacksonMixin;
 import uk.gov.justice.laa.crime.error.ErrorExtension;
 import uk.gov.justice.laa.crime.error.ErrorMessage;
 import uk.gov.justice.laa.crime.error.ProblemDetailError;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class ProblemDetailUtilTest {
 
@@ -70,7 +69,7 @@ class ProblemDetailUtilTest {
             assertThat(returnedErrors).isEqualTo(List.of(HttpStatus.BAD_REQUEST.getReasonPhrase()));
         } else {
             List<String> returnedErrors = ProblemDetailUtil.getErrorDetails(problemDetail);
-            assertThat(returnedErrors).isEqualTo(Collections.emptyList());
+            assertThat(returnedErrors).isEmpty();
         }
 
     }
@@ -83,7 +82,7 @@ class ProblemDetailUtilTest {
         List<String> returnedErrors = (useDefault) ?
                 ProblemDetailUtil.getErrorDetailsWithDefault(problemDetail) :
                 ProblemDetailUtil.getErrorDetails(problemDetail);
-        assertThat(returnedErrors).isEqualTo(List.of());
+        assertThat(returnedErrors).isEmpty();
     }
 
 
@@ -110,7 +109,7 @@ class ProblemDetailUtilTest {
     @Test
     void givenNoProblemDetail_whenNullPassedIn_thenEmptyListReturned() {
         List<String> returnedErrors = ProblemDetailUtil.getErrorDetailsWithDefault(null);
-        assertThat(returnedErrors).isEqualTo(List.of());
+        assertThat(returnedErrors).isEmpty();
     }
 
     @Test
@@ -149,8 +148,10 @@ class ProblemDetailUtilTest {
 
         Optional<ErrorExtension> foundExtension = ProblemDetailUtil.getErrorExtension(
                 problemDetail);
-        assertThat(foundExtension).isPresent();
-        assertThat(foundExtension).contains(expectedExtension);
+
+        assertThat(foundExtension)
+                .isPresent()
+                .contains(expectedExtension);
     }
 
     @Test
@@ -208,7 +209,7 @@ class ProblemDetailUtilTest {
         ProblemDetail actualProblemDetail = ProblemDetailUtil.parseProblemDetailJson(json);
 
         assertThat(actualProblemDetail).isEqualTo(expectedProblemDetail);
-        assertFalse(ProblemDetailUtil.getErrorExtension(actualProblemDetail).isPresent());
+        assertThat(ProblemDetailUtil.getErrorExtension(actualProblemDetail)).isEmpty();
     }
 
     @Test
@@ -221,7 +222,7 @@ class ProblemDetailUtilTest {
         ProblemDetail actualProblemDetail = ProblemDetailUtil.parseProblemDetailJson(json);
 
         assertThat(actualProblemDetail).isEqualTo(expectedProblemDetail);
-        assertFalse(ProblemDetailUtil.getErrorExtension(actualProblemDetail).isPresent());
+        assertThat(ProblemDetailUtil.getErrorExtension(actualProblemDetail)).isEmpty();
 
     }
 

--- a/crime-commons-classes/src/test/java/uk/gov/justice/laa/crime/util/ProblemDetailUtilTest.java
+++ b/crime-commons-classes/src/test/java/uk/gov/justice/laa/crime/util/ProblemDetailUtilTest.java
@@ -25,13 +25,70 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ProblemDetailUtilTest {
 
     @Test
-    void givenErrorList_whenErrorResponseWanted_ErrorListPresent() {
-        ErrorExtension extension = createErrorExtension(2);
-        ProblemDetail problemDetail = ProblemDetailUtil.buildProblemDetail(HttpStatus.BAD_REQUEST,
-                HttpStatus.BAD_REQUEST.getReasonPhrase(), extension);
-        assertThat(problemDetail).isNotNull();
+    void givenAllDetails_whenBuildCalled_thenFullDetailReturned() {
+
+        ErrorExtension expectedExtension = createErrorExtension(2);
+        ProblemDetail problemDetail =
+                ProblemDetailUtil.buildProblemDetail(HttpStatus.BAD_REQUEST, "title", "type",
+                        "detail", "instance", expectedExtension);
+
+        assertThat(problemDetail.getTitle()).isEqualTo("title");
+        assertThat(problemDetail.getType()).isEqualTo(URI.create("type"));
+        assertThat(problemDetail.getDetail()).isEqualTo("detail");
+        assertThat(problemDetail.getInstance()).isEqualTo(URI.create("instance"));
+        assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+
+        Optional<ErrorExtension> foundExtension = ProblemDetailUtil.getErrorExtension(
+                problemDetail);
+
+        assertThat(foundExtension)
+                .isPresent()
+                .contains(expectedExtension);
+    }
+
+    @Test
+    void givenProblemDetailError_whenBuildProblemDetailCalled_thenUsesDefaultDetailAndCode() {
+        List<ErrorMessage> messages = List.of(new ErrorMessage("field", "message"));
+
+        ProblemDetail problemDetail = ProblemDetailUtil.buildProblemDetail(
+                HttpStatus.BAD_REQUEST,
+                ProblemDetailError.VALIDATION_FAILURE,
+                "trace-123",
+                messages);
+
+        assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(problemDetail.getDetail()).
+                isEqualTo(ProblemDetailError.VALIDATION_FAILURE.defaultDetail());
+
         assertThat(ProblemDetailUtil.getErrorExtension(problemDetail))
-                .contains(extension);
+                .contains(new ErrorExtension(
+                        ProblemDetailError.VALIDATION_FAILURE.code(),
+                        "trace-123",
+                        messages));
+    }
+
+    @Test
+    void givenExtensionDetails_whenBuildExtensionCalled_populatesCorrectly() {
+        ErrorExtension expectedExtension = createErrorExtension(2);
+
+        ErrorExtension actualExtension = ProblemDetailUtil.buildErrorExtension(
+                expectedExtension.code(), expectedExtension.traceId(), expectedExtension.errors());
+
+        assertThat(actualExtension).isEqualTo(expectedExtension);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void givenProblemDetailWithDetailOnly_whenErrorDetailsRequested_thenReturnsExpectedResult(boolean useDefault) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST,
+                HttpStatus.BAD_REQUEST.getReasonPhrase());
+        if (useDefault) {
+            List<String> returnedErrors = ProblemDetailUtil.getErrorDetailsWithDefault(problemDetail);
+            assertThat(returnedErrors).isEqualTo(List.of(HttpStatus.BAD_REQUEST.getReasonPhrase()));
+        } else {
+            List<String> returnedErrors = ProblemDetailUtil.getErrorDetails(problemDetail);
+            assertThat(returnedErrors).isEmpty();
+        }
     }
 
     // Test without using utility constructor. Verify getter behaviour.
@@ -58,22 +115,6 @@ class ProblemDetailUtilTest {
                 ProblemDetailUtil.getErrorDetails(problemDetail);
         assertThat(returnedErrors).isEqualTo(getErrorsFromExtension(extension));
     }
-
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    void givenNoListButHasDetail_whenProblemDetailExamined_thenListOfDetailReturned(boolean useDefault) {
-        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST,
-                HttpStatus.BAD_REQUEST.getReasonPhrase());
-        if (useDefault) {
-            List<String> returnedErrors = ProblemDetailUtil.getErrorDetailsWithDefault(problemDetail);
-            assertThat(returnedErrors).isEqualTo(List.of(HttpStatus.BAD_REQUEST.getReasonPhrase()));
-        } else {
-            List<String> returnedErrors = ProblemDetailUtil.getErrorDetails(problemDetail);
-            assertThat(returnedErrors).isEmpty();
-        }
-
-    }
-
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
@@ -113,67 +154,24 @@ class ProblemDetailUtilTest {
     }
 
     @Test
-    void givenProblemDetailError_whenBuildProblemDetailCalled_thenUsesDefaultDetailAndCode() {
-        List<ErrorMessage> messages = List.of(new ErrorMessage("field", "message"));
-
-        ProblemDetail problemDetail = ProblemDetailUtil.buildProblemDetail(
-                HttpStatus.BAD_REQUEST,
-                ProblemDetailError.VALIDATION_FAILURE,
-                "trace-123",
-                messages);
-
-        assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
-        assertThat(problemDetail.getDetail()).isEqualTo(ProblemDetailError.VALIDATION_FAILURE.defaultDetail());
-
+    void givenProblemDetailWithExtension_whenGetErrorExtension_thenReturnsExtension() {
+        ErrorExtension extension = createErrorExtension(2);
+        ProblemDetail problemDetail = ProblemDetailUtil.buildProblemDetail(HttpStatus.BAD_REQUEST,
+                HttpStatus.BAD_REQUEST.getReasonPhrase(), extension);
+        assertThat(problemDetail).isNotNull();
         assertThat(ProblemDetailUtil.getErrorExtension(problemDetail))
-                .contains(new ErrorExtension(
-                        ProblemDetailError.VALIDATION_FAILURE.code(),
-                        "trace-123",
-                        messages));
+                .contains(extension);
     }
-
-    @Test
-    void givenAllDetails_whenBuildCalled_thenFullDetailReturned() {
-
-        ErrorExtension expectedExtension = createErrorExtension(2);
-        ProblemDetail problemDetail =
-                ProblemDetailUtil.buildProblemDetail(HttpStatus.BAD_REQUEST, "title", "type",
-                        "detail", "instance", expectedExtension);
-
-        assertThat(problemDetail.getTitle()).isEqualTo("title");
-        assertThat(problemDetail.getType()).isEqualTo(URI.create("type"));
-        assertThat(problemDetail.getDetail()).isEqualTo("detail");
-        assertThat(problemDetail.getInstance()).isEqualTo(URI.create("instance"));
-        assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
-
-        Optional<ErrorExtension> foundExtension = ProblemDetailUtil.getErrorExtension(
-                problemDetail);
-
-        assertThat(foundExtension)
-                .isPresent()
-                .contains(expectedExtension);
-    }
-
-    @Test
-    void givenExtensionDetails_whenBuildExtensionCalled_populatesCorrectly() {
-        ErrorExtension expectedExtension = createErrorExtension(2);
-
-        ErrorExtension actualExtension = ProblemDetailUtil.buildErrorExtension(
-                expectedExtension.code(), expectedExtension.traceId(), expectedExtension.errors());
-
-        assertThat(actualExtension).isEqualTo(expectedExtension);
-    }
-
 
     /**
      * Format of incoming json can be different if the endpoint responding is using the jackson mixin correctly.
      * If using, the values in properties get moved to the top level.
      * i.e.
      * {
-     *  "type" : "whatever"
-     *  "errors" : {
-     *      "code" : "TestCode"
-     *  }
+     * "type" : "whatever"
+     * "errors" : {
+     * "code" : "TestCode"
+     * }
      * }
      * Need to be able to handle both versions.
      */
@@ -181,7 +179,7 @@ class ProblemDetailUtilTest {
     @ValueSource(booleans = {true, false})
     void givenProblemDetail_whenParseIsCalled_populatesCorrectly(boolean useMixins) throws JsonProcessingException {
         ErrorExtension expectedExtension = createErrorExtension(2);
-        ProblemDetail  expectedProblemDetail = ProblemDetailUtil.buildProblemDetail(HttpStatus.BAD_REQUEST, "Detail", expectedExtension);
+        ProblemDetail expectedProblemDetail = ProblemDetailUtil.buildProblemDetail(HttpStatus.BAD_REQUEST, "Detail", expectedExtension);
         ObjectMapper objectMapper = new ObjectMapper();
         if (useMixins) {
             objectMapper.addMixIn(ProblemDetail.class, ProblemDetailJacksonMixin.class);
@@ -198,7 +196,7 @@ class ProblemDetailUtilTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void givenProblemDetailWithNoExtension_whenParseIsCalled_populatesCorrectly(boolean useMixins) throws JsonProcessingException {
-        ProblemDetail  expectedProblemDetail = ProblemDetailUtil.buildProblemDetail(HttpStatus.BAD_REQUEST, "Detail", null);
+        ProblemDetail expectedProblemDetail = ProblemDetailUtil.buildProblemDetail(HttpStatus.BAD_REQUEST, "Detail", null);
         ObjectMapper objectMapper = new ObjectMapper();
         if (useMixins) {
             objectMapper.addMixIn(ProblemDetail.class, ProblemDetailJacksonMixin.class);
@@ -214,7 +212,7 @@ class ProblemDetailUtilTest {
 
     @Test
     void givenNoExtensions_whenParseIsCalled_populatesCorrectly() throws JsonProcessingException {
-        ProblemDetail  expectedProblemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "TestDetail");
+        ProblemDetail expectedProblemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "TestDetail");
 
         ObjectMapper objectMapper = new ObjectMapper();
         String json = objectMapper.writeValueAsString(expectedProblemDetail);
@@ -223,7 +221,14 @@ class ProblemDetailUtilTest {
 
         assertThat(actualProblemDetail).isEqualTo(expectedProblemDetail);
         assertThat(ProblemDetailUtil.getErrorExtension(actualProblemDetail)).isEmpty();
+    }
 
+    @Test
+    void givenProblemDetailWithUnsupportedExtensionType_whenGetErrorExtension_thenReturnsEmpty() {
+        ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
+        problemDetail.setProperties(Map.of(ErrorExtension.EXTENSION_KEY, "not-an-extension"));
+
+        assertThat(ProblemDetailUtil.getErrorExtension(problemDetail)).isEmpty();
     }
 
     private List<ErrorMessage> createErrorMessages(int numValues) {

--- a/crime-commons-classes/src/test/java/uk/gov/justice/laa/crime/util/ProblemDetailUtilTest.java
+++ b/crime-commons-classes/src/test/java/uk/gov/justice/laa/crime/util/ProblemDetailUtilTest.java
@@ -24,18 +24,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ProblemDetailUtilTest {
 
+    private static final String CODE = "code";
+    private static final String TRACE_ID = "trace-123";
+    private static final String TEST_DETAIL = "TestDetail";
+
     @Test
     void givenAllDetails_whenBuildCalled_thenFullDetailReturned() {
 
+        String title = "title";
+        String type = "type";
+        String instance = "instance";
+
         ErrorExtension expectedExtension = createErrorExtension(2);
         ProblemDetail problemDetail =
-                ProblemDetailUtil.buildProblemDetail(HttpStatus.BAD_REQUEST, "title", "type",
-                        "detail", "instance", expectedExtension);
+                ProblemDetailUtil.buildProblemDetail(HttpStatus.BAD_REQUEST, title, type,
+                        TEST_DETAIL, instance, expectedExtension);
 
-        assertThat(problemDetail.getTitle()).isEqualTo("title");
-        assertThat(problemDetail.getType()).isEqualTo(URI.create("type"));
-        assertThat(problemDetail.getDetail()).isEqualTo("detail");
-        assertThat(problemDetail.getInstance()).isEqualTo(URI.create("instance"));
+        assertThat(problemDetail.getTitle()).isEqualTo(title);
+        assertThat(problemDetail.getType()).isEqualTo(URI.create(type));
+        assertThat(problemDetail.getDetail()).isEqualTo(TEST_DETAIL);
+        assertThat(problemDetail.getInstance()).isEqualTo(URI.create(instance));
         assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
 
         Optional<ErrorExtension> foundExtension = ProblemDetailUtil.getErrorExtension(
@@ -53,7 +61,7 @@ class ProblemDetailUtilTest {
         ProblemDetail problemDetail = ProblemDetailUtil.buildProblemDetail(
                 HttpStatus.BAD_REQUEST,
                 ProblemDetailError.VALIDATION_FAILURE,
-                "trace-123",
+                TRACE_ID,
                 messages);
 
         assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
@@ -63,7 +71,7 @@ class ProblemDetailUtilTest {
         assertThat(ProblemDetailUtil.getErrorExtension(problemDetail))
                 .contains(new ErrorExtension(
                         ProblemDetailError.VALIDATION_FAILURE.code(),
-                        "trace-123",
+                        TRACE_ID,
                         messages));
     }
 
@@ -99,7 +107,7 @@ class ProblemDetailUtilTest {
         assertThat(returnedErrors).isEmpty();
     }
 
-    // Test without using utility constructor. Verify getter behaviour.
+    // Test without using a utility constructor. Verify getter behaviour.
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void givenErrorListPresent_whenProblemDetailPassedIn_thenSameErrorListReturned(boolean useDefault) {
@@ -139,7 +147,7 @@ class ProblemDetailUtilTest {
     void givenListAndDetail_whenGetListIsCalled_thenOnlyListReturned() {
         ErrorExtension extension = createErrorExtension(2);
         ProblemDetail problemDetail = ProblemDetailUtil.buildProblemDetail(HttpStatus.BAD_REQUEST,
-                "detail", extension);
+                TEST_DETAIL, extension);
 
         List<String> returnedErrors = ProblemDetailUtil.getErrorDetailsWithDefault(problemDetail);
         assertThat(returnedErrors).isEqualTo(getErrorsFromExtension(extension));
@@ -147,12 +155,11 @@ class ProblemDetailUtilTest {
 
     @Test
     void givenListPresentButEmpty_whenProblemDetailPassedIn_thenListOfDetailReturned() {
-        ErrorExtension extension = new ErrorExtension("code", "trace", List.of());
-        ProblemDetail detail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST,
-                "Test Detail To Be Found");
+        ErrorExtension extension = new ErrorExtension(CODE, TRACE_ID, List.of());
+        ProblemDetail detail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, TEST_DETAIL);
         detail.setProperties(Map.of(ErrorExtension.EXTENSION_KEY, extension));
         List<String> returnedErrors = ProblemDetailUtil.getErrorDetailsWithDefault(detail);
-        assertThat(returnedErrors).isEqualTo(List.of("Test Detail To Be Found"));
+        assertThat(returnedErrors).isEqualTo(List.of(TEST_DETAIL));
     }
 
     @Test
@@ -191,7 +198,7 @@ class ProblemDetailUtilTest {
     @ValueSource(booleans = {true, false})
     void givenProblemDetail_whenParseIsCalled_populatesCorrectly(boolean useMixins) throws JsonProcessingException {
         ErrorExtension expectedExtension = createErrorExtension(2);
-        ProblemDetail expectedProblemDetail = ProblemDetailUtil.buildProblemDetail(HttpStatus.BAD_REQUEST, "Detail", expectedExtension);
+        ProblemDetail expectedProblemDetail = ProblemDetailUtil.buildProblemDetail(HttpStatus.BAD_REQUEST, TEST_DETAIL, expectedExtension);
         ObjectMapper objectMapper = new ObjectMapper();
         if (useMixins) {
             objectMapper.addMixIn(ProblemDetail.class, ProblemDetailJacksonMixin.class);
@@ -208,7 +215,7 @@ class ProblemDetailUtilTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void givenProblemDetailWithNoExtension_whenParseIsCalled_populatesCorrectly(boolean useMixins) throws JsonProcessingException {
-        ProblemDetail expectedProblemDetail = ProblemDetailUtil.buildProblemDetail(HttpStatus.BAD_REQUEST, "Detail", null);
+        ProblemDetail expectedProblemDetail = ProblemDetailUtil.buildProblemDetail(HttpStatus.BAD_REQUEST, TEST_DETAIL, null);
         ObjectMapper objectMapper = new ObjectMapper();
         if (useMixins) {
             objectMapper.addMixIn(ProblemDetail.class, ProblemDetailJacksonMixin.class);
@@ -224,7 +231,7 @@ class ProblemDetailUtilTest {
 
     @Test
     void givenNoExtensions_whenParseIsCalled_populatesCorrectly() throws JsonProcessingException {
-        ProblemDetail expectedProblemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "TestDetail");
+        ProblemDetail expectedProblemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, TEST_DETAIL);
 
         ObjectMapper objectMapper = new ObjectMapper();
         String json = objectMapper.writeValueAsString(expectedProblemDetail);
@@ -251,7 +258,7 @@ class ProblemDetailUtilTest {
     }
 
     private ErrorExtension createErrorExtension(int numValues) {
-        return new ErrorExtension("TestCode", "Test Trace ID", createErrorMessages(numValues));
+        return new ErrorExtension(CODE, TRACE_ID, createErrorMessages(numValues));
     }
 
     private List<String> getErrorsFromExtension(ErrorExtension extension) {

--- a/crime-commons-classes/src/test/java/uk/gov/justice/laa/crime/util/ProblemDetailUtilTest.java
+++ b/crime-commons-classes/src/test/java/uk/gov/justice/laa/crime/util/ProblemDetailUtilTest.java
@@ -64,11 +64,10 @@ class ProblemDetailUtilTest {
     void givenNoListButHasDetail_whenProblemDetailExamined_thenListOfDetailReturned(boolean useDefault) {
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST,
                 HttpStatus.BAD_REQUEST.getReasonPhrase());
-        if(useDefault) {
+        if (useDefault) {
             List<String> returnedErrors = ProblemDetailUtil.getErrorDetailsWithDefault(problemDetail);
             assertThat(returnedErrors).isEqualTo(List.of(HttpStatus.BAD_REQUEST.getReasonPhrase()));
-        }
-        else{
+        } else {
             List<String> returnedErrors = ProblemDetailUtil.getErrorDetails(problemDetail);
             assertThat(returnedErrors).isEqualTo(Collections.emptyList());
         }
@@ -162,7 +161,7 @@ class ProblemDetailUtilTest {
         ErrorExtension expectedExtension = createErrorExtension(2);
         ProblemDetail  expectedProblemDetail = ProblemDetailUtil.buildProblemDetail(HttpStatus.BAD_REQUEST, "Detail", expectedExtension);
         ObjectMapper objectMapper = new ObjectMapper();
-        if(useMixins) {
+        if (useMixins) {
             objectMapper.addMixIn(ProblemDetail.class, ProblemDetailJacksonMixin.class);
         }
         String json = objectMapper.writeValueAsString(expectedProblemDetail);
@@ -179,7 +178,7 @@ class ProblemDetailUtilTest {
     void givenProblemDetailWithNoExtension_whenParseIsCalled_populatesCorrectly(boolean useMixins) throws JsonProcessingException {
         ProblemDetail  expectedProblemDetail = ProblemDetailUtil.buildProblemDetail(HttpStatus.BAD_REQUEST, "Detail", null);
         ObjectMapper objectMapper = new ObjectMapper();
-        if(useMixins) {
+        if (useMixins) {
             objectMapper.addMixIn(ProblemDetail.class, ProblemDetailJacksonMixin.class);
         }
 

--- a/crime-commons-classes/src/test/java/uk/gov/justice/laa/crime/util/ProblemDetailUtilTest.java
+++ b/crime-commons-classes/src/test/java/uk/gov/justice/laa/crime/util/ProblemDetailUtilTest.java
@@ -57,8 +57,8 @@ class ProblemDetailUtilTest {
                 messages);
 
         assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
-        assertThat(problemDetail.getDetail()).
-                isEqualTo(ProblemDetailError.VALIDATION_FAILURE.defaultDetail());
+        assertThat(problemDetail.getDetail())
+                .isEqualTo(ProblemDetailError.VALIDATION_FAILURE.defaultDetail());
 
         assertThat(ProblemDetailUtil.getErrorExtension(problemDetail))
                 .contains(new ErrorExtension(
@@ -77,18 +77,26 @@ class ProblemDetailUtilTest {
         assertThat(actualExtension).isEqualTo(expectedExtension);
     }
 
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    void givenProblemDetailWithDetailOnly_whenErrorDetailsRequested_thenReturnsExpectedResult(boolean useDefault) {
-        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST,
+    @Test
+    void givenProblemDetailWithDetailOnly_whenGetErrorDetailsWithDefault_thenReturnsDetail() {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
+                HttpStatus.BAD_REQUEST,
                 HttpStatus.BAD_REQUEST.getReasonPhrase());
-        if (useDefault) {
-            List<String> returnedErrors = ProblemDetailUtil.getErrorDetailsWithDefault(problemDetail);
-            assertThat(returnedErrors).isEqualTo(List.of(HttpStatus.BAD_REQUEST.getReasonPhrase()));
-        } else {
-            List<String> returnedErrors = ProblemDetailUtil.getErrorDetails(problemDetail);
-            assertThat(returnedErrors).isEmpty();
-        }
+
+        List<String> returnedErrors = ProblemDetailUtil.getErrorDetailsWithDefault(problemDetail);
+
+        assertThat(returnedErrors).containsExactly(HttpStatus.BAD_REQUEST.getReasonPhrase());
+    }
+
+    @Test
+    void givenProblemDetailWithDetailOnly_whenGetErrorDetails_thenReturnsEmptyList() {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
+                HttpStatus.BAD_REQUEST,
+                HttpStatus.BAD_REQUEST.getReasonPhrase());
+
+        List<String> returnedErrors = ProblemDetailUtil.getErrorDetails(problemDetail);
+
+        assertThat(returnedErrors).isEmpty();
     }
 
     // Test without using utility constructor. Verify getter behaviour.

--- a/crime-commons-classes/src/test/java/uk/gov/justice/laa/crime/util/ProblemDetailUtilTest.java
+++ b/crime-commons-classes/src/test/java/uk/gov/justice/laa/crime/util/ProblemDetailUtilTest.java
@@ -172,16 +172,21 @@ class ProblemDetailUtilTest {
     }
 
     /**
-     * Format of incoming json can be different if the endpoint responding is using the jackson mixin correctly.
-     * If using, the values in properties get moved to the top level.
-     * i.e.
+     * Incoming JSON can vary depending on whether the responding endpoint uses the
+     * {@link ProblemDetailJacksonMixin}. When it does, values in {@code properties}
+     * are flattened to the top level.
+     *
+     * <p>For example:
+     * <pre>
      * {
-     * "type" : "whatever"
-     * "errors" : {
-     * "code" : "TestCode"
+     *   "type": "whatever",
+     *   "errors": {
+     *     "code": "TestCode"
+     *   }
      * }
-     * }
-     * Need to be able to handle both versions.
+     * </pre>
+     *
+     * Both forms should be supported.
      */
     @ParameterizedTest
     @ValueSource(booleans = {true, false})

--- a/crime-commons-mod-schemas/build.gradle
+++ b/crime-commons-mod-schemas/build.gradle
@@ -51,9 +51,9 @@ publishing {
                 }
                 developers {
                     developer {
-                        id = "Sriram"
-                        name = "Sriram Kasthuri"
-                        email = "sriram.kasthuri@digital.justice.gov.uk"
+                        id = "mhowell494"
+                        name = "Matthew Howell"
+                        email = "matthew.howell@digital.justice.gov.uk"
                     }
                 }
                 scm {

--- a/crime-commons-schemas/build.gradle
+++ b/crime-commons-schemas/build.gradle
@@ -51,9 +51,9 @@ publishing {
                 }
                 developers {
                     developer {
-                        id = "Michael"
-                        name = "Michael Clancy"
-                        email = "michael.clancy@digital.justice.gov.uk"
+                        id = "mhowell494"
+                        name = "Matthew Howell"
+                        email = "matthew.howell@digital.justice.gov.uk"
                     }
                 }
                 scm {


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-2023)

- Introduced a `ProblemDetailError` enum to standardise error codes and default details across services.
- Added a new `buildProblemDetail` overload in `ProblemDetailUtil` to simplify creation of `ProblemDetail` responses using the enum.

## Why
- Reduces repetition when constructing `ProblemDetail` responses.
- Promotes consistent error structures across services.
- Decouples shared error handling from service-specific enums.