### PR TITLE
LCAM-2018 - Update ErrorExtension Key

### DIFF
--- a/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/error/ErrorExtension.java
+++ b/crime-commons-classes/src/main/java/uk/gov/justice/laa/crime/error/ErrorExtension.java
@@ -12,7 +12,7 @@ import java.util.Objects;
  */
 public record ErrorExtension(String code, String traceId, List<ErrorMessage> errors) {
 
-    public static final String EXTENSION_KEY = "errors";
+    public static final String EXTENSION_KEY = "errorContext";
 
     public boolean hasErrors() {
         return (Objects.nonNull(errors) && !errors.isEmpty());


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-2018)

Updating the key that is used for ProblemDetails extension to avoid the double "errors" format confusion.
Tests already did a comparison to the actual key, so tests did not need fixing.
<img width="615" height="565" alt="image" src="https://github.com/user-attachments/assets/564cae1d-6ccf-4376-bc8a-ef40cec9d9b6" />
