### PR TITLE
Lasb 4590 add partner details to schema

### DIFF
--- a/crime-commons-schemas/build.gradle
+++ b/crime-commons-schemas/build.gradle
@@ -109,10 +109,6 @@ jsonSchema2Pojo {
     }
 }
 
-tasks.withType(Sign) {
-    onlyIf { !gradle.taskGraph.hasTask(":${project.name}:publishMavenPublicationToMavenLocal") }
-}
-
 tasks.sourcesJar.dependsOn("generateJsonSchema2DataClassConfigCriminalapplicationsdatastore")
 tasks.sourcesJar.dependsOn("generateJsonSchema2DataClassConfigCrimeapplication")
 tasks.sourcesJar.dependsOn("generateJsonSchema2DataClassConfigAtis")

--- a/crime-commons-schemas/build.gradle
+++ b/crime-commons-schemas/build.gradle
@@ -109,6 +109,10 @@ jsonSchema2Pojo {
     }
 }
 
+tasks.withType(Sign) {
+    onlyIf { !gradle.taskGraph.hasTask(":${project.name}:publishMavenPublicationToMavenLocal") }
+}
+
 tasks.sourcesJar.dependsOn("generateJsonSchema2DataClassConfigCriminalapplicationsdatastore")
 tasks.sourcesJar.dependsOn("generateJsonSchema2DataClassConfigCrimeapplication")
 tasks.sourcesJar.dependsOn("generateJsonSchema2DataClassConfigAtis")

--- a/crime-commons-schemas/src/main/resources/schemas/crimeapplication/common/partner.json
+++ b/crime-commons-schemas/src/main/resources/schemas/crimeapplication/common/partner.json
@@ -1,0 +1,59 @@
+{
+  "title": "Partner",
+  "description": "Represents the partner of the person who has made the application for Legal Aid",
+  "type": "object",
+  "properties": {
+    "firstName": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The partner's first name."
+    },
+    "otherNames": {
+      "type": "string",
+      "nullable": true
+    },
+    "surname": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The partner's surname (last name)."
+    },
+    "dateOfBirth": {
+      "type": "string",
+      "format": "date",
+      "description": "The partner's date of birth."
+    },
+    "niNumber": {
+      "type": "string",
+      "nullable": true,
+      "description": "The partner's National Insurance Number."
+    },
+    "dwpResponse": {
+      "type": "string",
+      "nullable": true,
+      "enum": ["Undetermined", "No", "Yes"]
+    },
+    "benefitType": {
+      "type": "string",
+      "nullable": true,
+      "enum": ["universal_credit", "guarantee_pension", "jsa", "esa", "income_support", "none"]
+    },
+    "last_jsa_appointment_date": {
+      "type": "string",
+      "nullable": true,
+      "format": "date"
+    },
+    "involvement_in_case": {
+      "type": "string",
+      "nullable": true,
+      "enum": ["victim", "prosecution_witness", "codefendant", "none"]
+    },
+    "conflict_of_interest": {
+      "anyOf": [
+        { "type": "null" },
+        { "type": "string",
+          "enum": ["yes", "no"]
+        }
+      ]
+    }
+  }
+}

--- a/crime-commons-schemas/src/main/resources/schemas/crimeapplication/common/partner.json
+++ b/crime-commons-schemas/src/main/resources/schemas/crimeapplication/common/partner.json
@@ -37,17 +37,17 @@
       "nullable": true,
       "enum": ["universal_credit", "guarantee_pension", "jsa", "esa", "income_support", "none"]
     },
-    "last_jsa_appointment_date": {
+    "lastJsaAppointmentDate": {
       "type": "string",
       "nullable": true,
       "format": "date"
     },
-    "involvement_in_case": {
+    "involvementInCase": {
       "type": "string",
       "nullable": true,
       "enum": ["victim", "prosecution_witness", "codefendant", "none"]
     },
-    "conflict_of_interest": {
+    "conflictOfInterest": {
       "anyOf": [
         { "type": "null" },
         { "type": "string",

--- a/crime-commons-schemas/src/main/resources/schemas/crimeapplication/common/partner.json
+++ b/crime-commons-schemas/src/main/resources/schemas/crimeapplication/common/partner.json
@@ -48,12 +48,7 @@
       "enum": ["victim", "prosecution_witness", "codefendant", "none"]
     },
     "conflictOfInterest": {
-      "anyOf": [
-        { "type": "null" },
-        { "type": "string",
-          "enum": ["yes", "no"]
-        }
-      ]
+      "anyOf": [{ "type": "null" }, { "type": "string", "enum": ["yes", "no"] }]
     }
   }
 }

--- a/crime-commons-schemas/src/main/resources/schemas/crimeapplication/maat_application_internal.json
+++ b/crime-commons-schemas/src/main/resources/schemas/crimeapplication/maat_application_internal.json
@@ -121,6 +121,9 @@
     "applicant": {
       "$ref": "#/definitions/applicant"
     },
+    "partner": {
+      "$ref": "#/definitions/partner"
+    },
     "supplier": {
       "$ref": "#/definitions/supplier"
     },
@@ -162,6 +165,9 @@
   "definitions": {
     "applicant": {
       "$ref": "common/applicant.json"
+    },
+    "partner": {
+      "$ref": "common/partner.json"
     },
     "supplier": {
       "$ref": "common/supplier.json"


### PR DESCRIPTION
[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4590)

- Added partner to common schema to enable injection of partner details (where available) when creating a new application from Crime Apply.
