### PR TITLE
Move "required" out of properties object in passport assessment metadata

### DIFF
--- a/crime-commons-mod-schemas/src/main/resources/schemas/passported/common/passportedAssessmentMetadata.json
+++ b/crime-commons-mod-schemas/src/main/resources/schemas/passported/common/passportedAssessmentMetadata.json
@@ -25,7 +25,7 @@
       "type": "object",
       "description": "Contains the username and session id for the user performing the request",
       "$ref": "../../common/apiUserSession.json"
-    },
-    "required": ["caseManagementUnitId", "userSession"]
-  }
+    }
+  },
+  "required": ["caseManagementUnitId", "userSession"]
 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-2075)

Describe what you did and why.

Tiny PR to move the required field out of the properties object to where it belongs, making sure the required fields are actually configured properly. 
