### PR TITLE
[LCAM-1888] Change the CircleCI config to a single workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,7 @@ workflows:
       - snyk_scan:
           requires:
             - build_and_test
-      
+
       # Rest client - main
       - major_release_approval_main_rest_client:
           type: approval
@@ -209,7 +209,7 @@ workflows:
             branches:
               only: main
           name: "Approve major release: rest client"
-            
+
       - publish_release:
           release_type: "major"
           module: "crime-commons-spring-boot-starter-rest-client"
@@ -260,7 +260,7 @@ workflows:
             branches:
               only: main
           name: "Publish patch release: rest client"
-      
+
       # Rest client - branch
       - snapshot_release_approval_rest_client:
           type: approval
@@ -270,7 +270,7 @@ workflows:
             branches:
               ignore: main
           name: "Approve snapshot release: rest client"
-  
+
       - publish_release:
           release_type: "snapshot"
           module: "crime-commons-spring-boot-starter-rest-client"
@@ -278,10 +278,10 @@ workflows:
           requires:
             - "Approve snapshot release: rest client"
           filters:
-              branches:
-                ignore: main
+            branches:
+              ignore: main
           name: "Publish snapshot release: rest client"
-      
+
       # Commons classes - main
       - major_release_approval_main_commons_classes:
           type: approval
@@ -342,7 +342,7 @@ workflows:
             branches:
               only: main
           name: "Publish patch release: commons classes"
-      
+
       # Commons classes - branch
       - snapshot_release_approval_commons_classes:
           type: approval
@@ -363,7 +363,7 @@ workflows:
             branches:
               ignore: main
           name: "Publish snapshot release: commons classes"
-      
+
       # Crime commons schemas - main
       - major_release_approval_main_crime_commons_schemas:
           type: approval
@@ -424,7 +424,7 @@ workflows:
             branches:
               only: main
           name: "Publish patch release: commons schemas"
-      
+
       # Crime commons schemas - branch
       - snapshot_release_approval_crime_commons_schemas:
           type: approval
@@ -445,7 +445,7 @@ workflows:
             branches:
               ignore: main
           name: "Publish snapshot release: commons schemas"
-      
+
       # Crime mod schemas - main
       - major_release_approval_main_crime_commons_mod_schemas:
           type: approval
@@ -506,7 +506,7 @@ workflows:
             branches:
               only: main
           name: "Publish patch release: commons mod schemas"
-      
+
       # Crime commons mod schemas - branch
       - snapshot_release_approval_crime_commons_mod_schemas:
           type: approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,18 +208,18 @@ workflows:
           filters:
             branches:
               only: main
-          name: "Approve major release: rest client"
-
+          name: "Rest client: Approve major release"
+            
       - publish_release:
           release_type: "major"
           module: "crime-commons-spring-boot-starter-rest-client"
           tagPrefix: "rest-client-"
           requires:
-            - "Approve major release: rest client"
+            - "Rest client: Approve major release"
           filters:
             branches:
               only: main
-          name: "Publish major release: rest client"
+          name: "Rest client: Publish major release"
 
       - minor_release_approval_main_rest_client:
           type: approval
@@ -228,18 +228,18 @@ workflows:
           filters:
             branches:
               only: main
-          name: "Approve minor release: rest client"
+          name: "Rest client: Approve minor release"
 
       - publish_release:
           release_type: "minor"
           module: "crime-commons-spring-boot-starter-rest-client"
           tagPrefix: "rest-client-"
           requires:
-            - "Approve minor release: rest client"
+            - "Rest client: Approve minor release"
           filters:
             branches:
               only: main
-          name: "Publish minor release: rest client"
+          name: "Rest client: Publish minor release"
 
       - patch_release_approval_main_rest_client:
           type: approval
@@ -248,19 +248,19 @@ workflows:
           filters:
             branches:
               only: main
-          name: "Approve patch release: rest client"
+          name: "Rest client: Approve patch release"
 
       - publish_release:
           release_type: "patch"
           module: "crime-commons-spring-boot-starter-rest-client"
           tagPrefix: "rest-client-"
           requires:
-            - "Approve patch release: rest client"
+            - "Rest client: Approve patch release"
           filters:
             branches:
               only: main
-          name: "Publish patch release: rest client"
-
+          name: "Rest client: Publish patch release"
+      
       # Rest client - branch
       - snapshot_release_approval_rest_client:
           type: approval
@@ -269,18 +269,18 @@ workflows:
           filters:
             branches:
               ignore: main
-          name: "Approve snapshot release: rest client"
-
+          name: "Rest client: Approve snapshot release"
+  
       - publish_release:
           release_type: "snapshot"
           module: "crime-commons-spring-boot-starter-rest-client"
           tagPrefix: "rest-client-"
           requires:
-            - "Approve snapshot release: rest client"
+            - "Rest client: Approve snapshot release"
           filters:
-            branches:
-              ignore: main
-          name: "Publish snapshot release: rest client"
+              branches:
+                ignore: main
+          name: "Rest client: Publish snapshot release"
 
       # Commons classes - main
       - major_release_approval_main_commons_classes:
@@ -290,18 +290,18 @@ workflows:
           filters:
             branches:
               only: main
-          name: "Approve major release: commons classes"
+          name: "Commons classes: Approve major release"
 
       - publish_release:
           release_type: "major"
           module: "crime-commons-classes"
           tagPrefix: "crime-commons-classes-"
           requires:
-            - "Approve major release: commons classes"
+            - "Commons classes: Approve major release"
           filters:
             branches:
               only: main
-          name: "Publish major release: commons classes"
+          name: "Commons classes: Publish major release"
 
       - minor_release_approval_main_commons_classes:
           type: approval
@@ -310,18 +310,18 @@ workflows:
           filters:
             branches:
               only: main
-          name: "Approve minor release: commons classes"
+          name: "Commons classes: Approve minor release"
 
       - publish_release:
           release_type: "minor"
           module: "crime-commons-classes"
           tagPrefix: "crime-commons-classes-"
           requires:
-            - "Approve minor release: commons classes"
+            - "Commons classes: Approve minor release"
           filters:
             branches:
               only: main
-          name: "Publish minor release: commons classes"
+          name: "Commons classes: Publish minor release"
 
       - patch_release_approval_main_commons_classes:
           type: approval
@@ -330,19 +330,19 @@ workflows:
           filters:
             branches:
               only: main
-          name: "Approve patch release: commons classes"
+          name: "Commons classes: Approve patch release"
 
       - publish_release:
           release_type: "patch"
           module: "crime-commons-classes"
           tagPrefix: "crime-commons-classes-"
           requires:
-            - "Approve patch release: commons classes"
+            - "Commons classes: Approve patch release"
           filters:
             branches:
               only: main
-          name: "Publish patch release: commons classes"
-
+          name: "Commons classes: Publish patch release"
+        
       # Commons classes - branch
       - snapshot_release_approval_commons_classes:
           type: approval
@@ -351,19 +351,19 @@ workflows:
           filters:
             branches:
               ignore: main
-          name: "Approve snapshot release: commons classes"
+          name: "Commons classes: Approve snapshot release"
 
       - publish_release:
           release_type: "snapshot"
           module: "crime-commons-classes"
           tagPrefix: "crime-commons-classes-"
           requires:
-            - "Approve snapshot release: commons classes"
+            - "Commons classes: Approve snapshot release"
           filters:
             branches:
               ignore: main
-          name: "Publish snapshot release: commons classes"
-
+          name: "Commons classes: Publish snapshot release"
+      
       # Crime commons schemas - main
       - major_release_approval_main_crime_commons_schemas:
           type: approval
@@ -372,18 +372,18 @@ workflows:
           filters:
             branches:
               only: main
-          name: "Approve major release: commons schemas"
+          name: "Commons schemas: Approve major release"
 
       - publish_release:
           release_type: "major"
           module: "crime-commons-schemas"
           tagPrefix: "crime-commons-schemas-"
           requires:
-            - "Approve major release: commons schemas"
+            - "Commons schemas: Approve major release"
           filters:
             branches:
               only: main
-          name: "Publish major release: commons schemas"
+          name: "Commons schemas: Publish major release"
 
       - minor_release_approval_main_crime_commons_schemas:
           type: approval
@@ -392,18 +392,18 @@ workflows:
           filters:
             branches:
               only: main
-          name: "Approve minor release: commons schemas"
+          name: "Commons schemas: Approve minor release"
 
       - publish_release:
           release_type: "minor"
           module: "crime-commons-schemas"
           tagPrefix: "crime-commons-schemas-"
           requires:
-            - "Approve minor release: commons schemas"
+            - "Commons schemas: Approve minor release"
           filters:
             branches:
               only: main
-          name: "Publish minor release: commons schemas"
+          name: "Commons schemas: Publish minor release"
 
       - patch_release_approval_main_crime_commons_schemas:
           type: approval
@@ -412,18 +412,18 @@ workflows:
           filters:
             branches:
               only: main
-          name: "Approve patch release: commons schemas"
+          name: "Commons schemas: Approve patch release"
 
       - publish_release:
           release_type: "patch"
           module: "crime-commons-schemas"
           tagPrefix: "crime-commons-schemas-"
           requires:
-            - "Approve patch release: commons schemas"
+            - "Commons schemas: Approve patch release"
           filters:
             branches:
               only: main
-          name: "Publish patch release: commons schemas"
+          name: "Commons schemas: Publish patch release"
 
       # Crime commons schemas - branch
       - snapshot_release_approval_crime_commons_schemas:
@@ -433,19 +433,19 @@ workflows:
           filters:
             branches:
               ignore: main
-          name: "Approve snapshot release: commons schemas"
+          name: "Commons schemas: Approve snapshot release"
 
       - publish_release:
           release_type: "snapshot"
           module: "crime-commons-schemas"
           tagPrefix: "crime-commons-schemas-"
           requires:
-            - "Approve snapshot release: commons schemas"
+            - "Commons schemas: Approve snapshot release"
           filters:
             branches:
               ignore: main
-          name: "Publish snapshot release: commons schemas"
-
+          name: "Commons schemas: Publish snapshot release"
+      
       # Crime mod schemas - main
       - major_release_approval_main_crime_commons_mod_schemas:
           type: approval
@@ -454,18 +454,18 @@ workflows:
           filters:
             branches:
               only: main
-          name: "Approve major release: commons mod schemas"
+          name: "Commons mod schemas: Approve major release"
 
       - publish_release:
           release_type: "major"
           module: "crime-commons-mod-schemas"
           tagPrefix: "crime-commons-mod-schemas-"
           requires:
-            - "Approve major release: commons mod schemas"
+            - "Commons mod schemas: Approve major release"
           filters:
             branches:
               only: main
-          name: "Publish major release: commons mod schemas"
+          name: "Commons mod schemas: Publish major release"
 
       - minor_release_approval_main_crime_commons_mod_schemas:
           type: approval
@@ -474,18 +474,18 @@ workflows:
           filters:
             branches:
               only: main
-          name: "Approve minor release: commons mod schemas"
+          name: "Commons mod schemas: Approve minor release"
 
       - publish_release:
           release_type: "minor"
           module: "crime-commons-mod-schemas"
           tagPrefix: "crime-commons-mod-schemas-"
           requires:
-            - "Approve minor release: commons mod schemas"
+            - "Commons mod schemas: Approve minor release"
           filters:
             branches:
               only: main
-          name: "Publish minor release: commons mod schemas"
+          name: "Commons mod schemas: Publish minor release"
 
       - patch_release_approval_main_crime_commons_mod_schemas:
           type: approval
@@ -494,19 +494,19 @@ workflows:
           filters:
             branches:
               only: main
-          name: "Approve patch release: commons mod schemas"
+          name: "Commons mod schemas: Approve patch release"
 
       - publish_release:
           release_type: "patch"
           module: "crime-commons-mod-schemas"
           tagPrefix: "crime-commons-mod-schemas-"
           requires:
-            - "Approve patch release: commons mod schemas"
+            - "Commons mod schemas: Approve patch release"
           filters:
             branches:
               only: main
-          name: "Publish patch release: commons mod schemas"
-
+          name: "Commons mod schemas: Publish patch release"
+      
       # Crime commons mod schemas - branch
       - snapshot_release_approval_crime_commons_mod_schemas:
           type: approval
@@ -515,15 +515,15 @@ workflows:
           filters:
             branches:
               ignore: main
-          name: "Approve snapshot release: commons mod schemas"
+          name: "Commons mod schemas: Approve snapshot release"
 
       - publish_release:
           release_type: "snapshot"
           module: "crime-commons-mod-schemas"
           tagPrefix: "crime-commons-mod-schemas-"
           requires:
-            - "Approve snapshot release: commons mod schemas"
+            - "Commons mod schemas: Approve snapshot release"
           filters:
             branches:
               ignore: main
-          name: "Publish snapshot release: commons mod schemas"
+          name: "Commons mod schemas: Publish snapshot release"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,334 +186,344 @@ jobs:
 workflows:
   version: 2
 
-  build_publish_main_rest_client:
+  build_and_release:
     jobs:
+      - start_build_and_test:
+          type: approval
+
       - build_and_test:
-          filters:
-            branches:
-              only:
-                - main
+          requires:
+            - start_build_and_test
           context: SonarCloud Crime
 
       - snyk_scan:
           requires:
             - build_and_test
-
-      - major_release_approval:
+      
+      # Rest client - main
+      - major_release_approval_main_rest_client:
           type: approval
           requires:
             - snyk_scan
-
+          filters:
+            branches:
+              only: main
+          name: "Approve major release: rest client"
+            
       - publish_release:
           release_type: "major"
           module: "crime-commons-spring-boot-starter-rest-client"
           tagPrefix: "rest-client-"
           requires:
-            - major_release_approval
+            - "Approve major release: rest client"
+          filters:
+            branches:
+              only: main
           name: "Publish major release: rest client"
 
-      - minor_release_approval:
+      - minor_release_approval_main_rest_client:
           type: approval
           requires:
             - snyk_scan
+          filters:
+            branches:
+              only: main
+          name: "Approve minor release: rest client"
 
       - publish_release:
           release_type: "minor"
           module: "crime-commons-spring-boot-starter-rest-client"
           tagPrefix: "rest-client-"
           requires:
-            - minor_release_approval
+            - "Approve minor release: rest client"
+          filters:
+            branches:
+              only: main
           name: "Publish minor release: rest client"
 
-      - patch_release_approval:
+      - patch_release_approval_main_rest_client:
           type: approval
           requires:
             - snyk_scan
+          filters:
+            branches:
+              only: main
+          name: "Approve patch release: rest client"
 
       - publish_release:
           release_type: "patch"
           module: "crime-commons-spring-boot-starter-rest-client"
           tagPrefix: "rest-client-"
           requires:
-            - patch_release_approval
-          name: "Publish patch release: rest client"
-
-  build_publish_branch_rest_client:
-    jobs:
-      - branch_build_approval:
-          type: approval
+            - "Approve patch release: rest client"
           filters:
             branches:
-              ignore:
-                - main
-
-      - build_and_test:
-          requires:
-            - branch_build_approval
-          context: SonarCloud Crime
-
-      - snyk_scan:
-          requires:
-            - build_and_test
-
-      - snapshot_release_approval:
+              only: main
+          name: "Publish patch release: rest client"
+      
+      # Rest client - branch
+      - snapshot_release_approval_rest_client:
           type: approval
           requires:
             - snyk_scan
-
+          filters:
+            branches:
+              ignore: main
+          name: "Approve snapshot release: rest client"
+  
       - publish_release:
           release_type: "snapshot"
           module: "crime-commons-spring-boot-starter-rest-client"
           tagPrefix: "rest-client-"
           requires:
-            - snapshot_release_approval
-          name: "Publish snapshot release: rest client"
-
-  build_publish_main_crime_commons_classes:
-    jobs:
-      - build_and_test:
+            - "Approve snapshot release: rest client"
           filters:
-            branches:
-              only:
-                - main
-          context: SonarCloud Crime
-
-      - snyk_scan:
-          requires:
-            - build_and_test
-
-      - major_release_approval:
+              branches:
+                ignore: main
+          name: "Publish snapshot release: rest client"
+      
+      # Commons classes - main
+      - major_release_approval_main_commons_classes:
           type: approval
           requires:
             - snyk_scan
+          filters:
+            branches:
+              only: main
+          name: "Approve major release: commons classes"
 
       - publish_release:
           release_type: "major"
           module: "crime-commons-classes"
           tagPrefix: "crime-commons-classes-"
           requires:
-            - major_release_approval
+            - "Approve major release: commons classes"
+          filters:
+            branches:
+              only: main
           name: "Publish major release: commons classes"
 
-      - minor_release_approval:
+      - minor_release_approval_main_commons_classes:
           type: approval
           requires:
             - snyk_scan
+          filters:
+            branches:
+              only: main
+          name: "Approve minor release: commons classes"
 
       - publish_release:
           release_type: "minor"
           module: "crime-commons-classes"
           tagPrefix: "crime-commons-classes-"
           requires:
-            - minor_release_approval
+            - "Approve minor release: commons classes"
+          filters:
+            branches:
+              only: main
           name: "Publish minor release: commons classes"
 
-      - patch_release_approval:
+      - patch_release_approval_main_commons_classes:
           type: approval
           requires:
             - snyk_scan
+          filters:
+            branches:
+              only: main
+          name: "Approve patch release: commons classes"
 
       - publish_release:
           release_type: "patch"
           module: "crime-commons-classes"
           tagPrefix: "crime-commons-classes-"
           requires:
-            - patch_release_approval
-          name: "Publish patch release: commons classes"
-
-  build_publish_branch_crime_commons_classes:
-    jobs:
-      - branch_build_approval:
-          type: approval
+            - "Approve patch release: commons classes"
           filters:
             branches:
-              ignore:
-                - main
-
-      - build_and_test:
-          requires:
-            - branch_build_approval
-          context: SonarCloud Crime
-
-      - snyk_scan:
-          requires:
-            - build_and_test
-
-      - snapshot_release_approval:
+              only: main
+          name: "Publish patch release: commons classes"
+      
+      # Commons classes - branch
+      - snapshot_release_approval_commons_classes:
           type: approval
           requires:
             - snyk_scan
+          filters:
+            branches:
+              ignore: main
+          name: "Approve snapshot release: commons classes"
 
       - publish_release:
           release_type: "snapshot"
           module: "crime-commons-classes"
           tagPrefix: "crime-commons-classes-"
           requires:
-            - snapshot_release_approval
-          name: "Publish snapshot release: commons classes"
-
-  build_publish_main_crime_commons_schemas:
-    jobs:
-      - build_and_test:
+            - "Approve snapshot release: commons classes"
           filters:
             branches:
-              only:
-                - main
-          context: SonarCloud Crime
-
-      - snyk_scan:
-          requires:
-            - build_and_test
-
-      - major_release_approval:
+              ignore: main
+          name: "Publish snapshot release: commons classes"
+      
+      # Crime commons schemas - main
+      - major_release_approval_main_crime_commons_schemas:
           type: approval
           requires:
             - snyk_scan
+          filters:
+            branches:
+              only: main
+          name: "Approve major release: commons schemas"
 
       - publish_release:
           release_type: "major"
           module: "crime-commons-schemas"
           tagPrefix: "crime-commons-schemas-"
           requires:
-            - major_release_approval
+            - "Approve major release: commons schemas"
+          filters:
+            branches:
+              only: main
           name: "Publish major release: commons schemas"
 
-      - minor_release_approval:
+      - minor_release_approval_main_crime_commons_schemas:
           type: approval
           requires:
             - snyk_scan
+          filters:
+            branches:
+              only: main
+          name: "Approve minor release: commons schemas"
 
       - publish_release:
           release_type: "minor"
           module: "crime-commons-schemas"
           tagPrefix: "crime-commons-schemas-"
           requires:
-            - minor_release_approval
+            - "Approve minor release: commons schemas"
+          filters:
+            branches:
+              only: main
           name: "Publish minor release: commons schemas"
 
-      - patch_release_approval:
+      - patch_release_approval_main_crime_commons_schemas:
           type: approval
           requires:
             - snyk_scan
+          filters:
+            branches:
+              only: main
+          name: "Approve patch release: commons schemas"
 
       - publish_release:
           release_type: "patch"
           module: "crime-commons-schemas"
           tagPrefix: "crime-commons-schemas-"
           requires:
-            - patch_release_approval
-          name: "Publish patch release: commons schemas"
-
-  build_publish_branch_crime_commons_schemas:
-    jobs:
-      - branch_build_approval:
-          type: approval
+            - "Approve patch release: commons schemas"
           filters:
             branches:
-              ignore:
-                - main
-
-      - build_and_test:
-          requires:
-            - branch_build_approval
-          context: SonarCloud Crime
-
-      - snyk_scan:
-          requires:
-            - build_and_test
-
-      - snapshot_release_approval:
+              only: main
+          name: "Publish patch release: commons schemas"
+      
+      # Crime commons schemas - branch
+      - snapshot_release_approval_crime_commons_schemas:
           type: approval
           requires:
             - snyk_scan
+          filters:
+            branches:
+              ignore: main
+          name: "Approve snapshot release: commons schemas"
 
       - publish_release:
           release_type: "snapshot"
           module: "crime-commons-schemas"
           tagPrefix: "crime-commons-schemas-"
           requires:
-            - snapshot_release_approval
-          name: "Publish snapshot release: commons schemas"
-
-  build_publish_main_crime_commons_mod_schemas:
-    jobs:
-      - build_and_test:
+            - "Approve snapshot release: commons schemas"
           filters:
             branches:
-              only:
-                - main
-          context: SonarCloud Crime
-
-      - snyk_scan:
-          requires:
-            - build_and_test
-
-      - major_release_approval:
+              ignore: main
+          name: "Publish snapshot release: commons schemas"
+      
+      # Crime mod schemas - main
+      - major_release_approval_main_crime_commons_mod_schemas:
           type: approval
           requires:
             - snyk_scan
+          filters:
+            branches:
+              only: main
+          name: "Approve major release: commons mod schemas"
 
       - publish_release:
           release_type: "major"
           module: "crime-commons-mod-schemas"
           tagPrefix: "crime-commons-mod-schemas-"
           requires:
-            - major_release_approval
+            - "Approve major release: commons mod schemas"
+          filters:
+            branches:
+              only: main
           name: "Publish major release: commons mod schemas"
 
-      - minor_release_approval:
+      - minor_release_approval_main_crime_commons_mod_schemas:
           type: approval
           requires:
             - snyk_scan
+          filters:
+            branches:
+              only: main
+          name: "Approve minor release: commons mod schemas"
 
       - publish_release:
           release_type: "minor"
           module: "crime-commons-mod-schemas"
           tagPrefix: "crime-commons-mod-schemas-"
           requires:
-            - minor_release_approval
+            - "Approve minor release: commons mod schemas"
+          filters:
+            branches:
+              only: main
           name: "Publish minor release: commons mod schemas"
 
-      - patch_release_approval:
+      - patch_release_approval_main_crime_commons_mod_schemas:
           type: approval
           requires:
             - snyk_scan
+          filters:
+            branches:
+              only: main
+          name: "Approve patch release: commons mod schemas"
 
       - publish_release:
           release_type: "patch"
           module: "crime-commons-mod-schemas"
           tagPrefix: "crime-commons-mod-schemas-"
           requires:
-            - patch_release_approval
-          name: "Publish patch release: commons mod schemas"
-
-  build_publish_branch_crime_commons_mod-schemas:
-    jobs:
-      - branch_build_approval:
-          type: approval
+            - "Approve patch release: commons mod schemas"
           filters:
             branches:
-              ignore:
-                - main
-
-      - build_and_test:
-          requires:
-            - branch_build_approval
-          context: SonarCloud Crime
-
-      - snyk_scan:
-          requires:
-            - build_and_test
-
-      - snapshot_release_approval:
+              only: main
+          name: "Publish patch release: commons mod schemas"
+      
+      # Crime commons mod schemas - branch
+      - snapshot_release_approval_crime_commons_mod_schemas:
           type: approval
           requires:
             - snyk_scan
+          filters:
+            branches:
+              ignore: main
+          name: "Approve snapshot release: commons mod schemas"
 
       - publish_release:
           release_type: "snapshot"
           module: "crime-commons-mod-schemas"
           tagPrefix: "crime-commons-mod-schemas-"
           requires:
-            - snapshot_release_approval
+            - "Approve snapshot release: commons mod schemas"
+          filters:
+            branches:
+              ignore: main
           name: "Publish snapshot release: commons mod schemas"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,7 +209,7 @@ workflows:
             branches:
               only: main
           name: "Rest client: Approve major release"
-            
+
       - publish_release:
           release_type: "major"
           module: "crime-commons-spring-boot-starter-rest-client"
@@ -260,7 +260,7 @@ workflows:
             branches:
               only: main
           name: "Rest client: Publish patch release"
-      
+
       # Rest client - branch
       - snapshot_release_approval_rest_client:
           type: approval
@@ -270,7 +270,7 @@ workflows:
             branches:
               ignore: main
           name: "Rest client: Approve snapshot release"
-  
+
       - publish_release:
           release_type: "snapshot"
           module: "crime-commons-spring-boot-starter-rest-client"
@@ -278,8 +278,8 @@ workflows:
           requires:
             - "Rest client: Approve snapshot release"
           filters:
-              branches:
-                ignore: main
+            branches:
+              ignore: main
           name: "Rest client: Publish snapshot release"
 
       # Commons classes - main
@@ -342,7 +342,7 @@ workflows:
             branches:
               only: main
           name: "Commons classes: Publish patch release"
-        
+
       # Commons classes - branch
       - snapshot_release_approval_commons_classes:
           type: approval
@@ -363,7 +363,7 @@ workflows:
             branches:
               ignore: main
           name: "Commons classes: Publish snapshot release"
-      
+
       # Crime commons schemas - main
       - major_release_approval_main_crime_commons_schemas:
           type: approval
@@ -445,7 +445,7 @@ workflows:
             branches:
               ignore: main
           name: "Commons schemas: Publish snapshot release"
-      
+
       # Crime mod schemas - main
       - major_release_approval_main_crime_commons_mod_schemas:
           type: approval
@@ -506,7 +506,7 @@ workflows:
             branches:
               only: main
           name: "Commons mod schemas: Publish patch release"
-      
+
       # Crime commons mod schemas - branch
       - snapshot_release_approval_crime_commons_mod_schemas:
           type: approval


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1888)

This is to remove duplication in the existing workflows. Currently the build_and_test step runs for every workflow, so if you want to deploy both mod schemas and commons classes for example, it'll build the same thing twice. We only need it to run once before we approve deployments. I've unified it into a single workflow and added an approval step at the beginning so it doesn't build for every push to a feature branch. 

This is how the new workflow looks for deployments on the main branch:

<img width="1425" height="654" alt="Screenshot 2026-05-06 at 11 07 48" src="https://github.com/user-attachments/assets/b1b3996c-0cb0-429b-8253-4925b021a50f" />

And here is how it looks for feature branches:

<img width="1542" height="332" alt="Screenshot 2026-05-06 at 11 07 29" src="https://github.com/user-attachments/assets/2780be3e-37fc-4041-872a-1498847d1963" />

