### PR TITLE
Ci workflow improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,8 @@ jobs:
       - restore_cache:
           keys:
             - v1-gradle-cache-{{ checksum "settings.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "build.gradle" }}-{{ checksum "crime-commons-spring-boot-starter-rest-client/build.gradle" }}-{{ checksum "crime-commons-classes/build.gradle" }}-{{ checksum "crime-commons-schemas/build.gradle" }}-{{ checksum "crime-commons-mod-schemas/build.gradle" }}
+            - v1-gradle-cache-{{ checksum "settings.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "build.gradle" }}-
+            - v1-gradle-cache-
 
       - run:
           name: Build and test all modules
@@ -116,7 +118,12 @@ jobs:
       - restore_cache:
           keys:
             - v1-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
-            - v1-gradle-cache-{{ checksum "<< pipeline.parameters.release_module >>/build.gradle" }}
+
+      - restore_cache:
+          keys:
+            - v1-gradle-cache-{{ checksum "settings.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "build.gradle" }}-{{ checksum "crime-commons-spring-boot-starter-rest-client/build.gradle" }}-{{ checksum "crime-commons-classes/build.gradle" }}-{{ checksum "crime-commons-schemas/build.gradle" }}-{{ checksum "crime-commons-mod-schemas/build.gradle" }}
+            - v1-gradle-cache-{{ checksum "settings.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "build.gradle" }}-
+            - v1-gradle-cache-
 
       - run:
           name: Publish release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ parameters:
   release_type:
     type: enum
     enum: ["major", "minor", "patch", "snapshot"]
-    default: "patch"
+    default: "snapshot"
     description: "The type of release to perform"
 
   release_module:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,20 +4,27 @@ orbs:
   snyk: snyk/snyk@1.1.2
 
 parameters:
+  action:
+    type: enum
+    enum: [ "build", "release" ]
+    default: "build"
+    description: "The action to perform"
+
   release_type:
     type: enum
-    enum: ["none", "major", "minor", "patch", "snapshot"]
-    default: "none"
+    enum: ["major", "minor", "patch", "snapshot"]
+    default: "patch"
+    description: "The type of release to perform"
 
   release_module:
     type: enum
     enum:
-      - "none"
       - "crime-commons-spring-boot-starter-rest-client"
       - "crime-commons-classes"
       - "crime-commons-schemas"
       - "crime-commons-mod-schemas"
-    default: "none"
+    default: "crime-commons-classes"
+    description: "The module to release"
 
 _snyk_options: &snyk_options
   project: "${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BRANCH}"
@@ -42,30 +49,6 @@ commands:
       - run: ssh-keyscan github.com >> ~/.ssh/known_hosts
 
 jobs:
-  validate_release_parameters:
-    executor: openjdk-executor
-    steps:
-      - run:
-          name: Validate release parameters
-          command: |
-            RELEASE_TYPE="<< pipeline.parameters.release_type >>"
-            RELEASE_MODULE="<< pipeline.parameters.release_module >>"
-
-            if [ "$RELEASE_TYPE" = "none" ] || [ "$RELEASE_MODULE" = "none" ]; then
-              echo "Both release_type and release_module must be set for a release."
-              exit 1
-            fi
-
-            if [ "$RELEASE_TYPE" = "snapshot" ] && [ "$CIRCLE_BRANCH" = "main" ]; then
-              echo "Snapshot releases must not be run from main."
-              exit 1
-            fi
-
-            if [ "$RELEASE_TYPE" != "snapshot" ] && [ "$CIRCLE_BRANCH" != "main" ]; then
-              echo "Major/minor/patch releases must only be run from main."
-              exit 1
-            fi
-
   build_and_test:
     environment:
       _JAVA_OPTIONS: "-Xmx3g"
@@ -160,6 +143,16 @@ jobs:
           command: |
             RELEASE_TYPE="<< pipeline.parameters.release_type >>"
             MODULE="<< pipeline.parameters.release_module >>"
+            
+            if [ "$RELEASE_TYPE" = "snapshot" ] && [ "$CIRCLE_BRANCH" = "main" ]; then
+              echo "Snapshot releases must not be run from main."
+              exit 1
+            fi
+  
+            if [ "$RELEASE_TYPE" != "snapshot" ] && [ "$CIRCLE_BRANCH" != "main" ]; then
+              echo "Major/minor/patch releases must only be run from main."
+              exit 1
+            fi
 
             case "$MODULE" in
               "crime-commons-spring-boot-starter-rest-client")
@@ -203,9 +196,7 @@ workflows:
 
   build:
     when:
-      and:
-        - equal: ["none", << pipeline.parameters.release_type >>]
-        - equal: ["none", << pipeline.parameters.release_module >>]
+      equal: ["build", << pipeline.parameters.action >>]
     jobs:
       - build_and_test:
           context: SonarCloud Crime
@@ -216,17 +207,10 @@ workflows:
 
   release:
     when:
-      or:
-        - not:
-            equal: ["none", << pipeline.parameters.release_type >>]
-        - not:
-            equal: ["none", << pipeline.parameters.release_module >>]
+      equal: ["release", << pipeline.parameters.action >>]
     jobs:
-      - validate_release_parameters
 
       - build_and_test:
-          requires:
-            - validate_release_parameters
           context: SonarCloud Crime
 
       - snyk_scan:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
       - restore_cache:
           keys:
             - v1-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
-            - v1-gradle-cache-{{ checksum "build.gradle" }}
+            - v1-gradle-cache-{{ checksum "<< pipeline.parameters.release_module >>/build.gradle" }}
 
       - run:
           name: Publish release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   action:
     type: enum
-    enum: [ "build", "release" ]
+    enum: ["build", "release"]
     default: "build"
     description: "The action to perform"
 
@@ -143,12 +143,12 @@ jobs:
           command: |
             RELEASE_TYPE="<< pipeline.parameters.release_type >>"
             MODULE="<< pipeline.parameters.release_module >>"
-            
+
             if [ "$RELEASE_TYPE" = "snapshot" ] && [ "$CIRCLE_BRANCH" = "main" ]; then
               echo "Snapshot releases must not be run from main."
               exit 1
             fi
-  
+
             if [ "$RELEASE_TYPE" != "snapshot" ] && [ "$CIRCLE_BRANCH" != "main" ]; then
               echo "Major/minor/patch releases must only be run from main."
               exit 1
@@ -209,7 +209,6 @@ workflows:
     when:
       equal: ["release", << pipeline.parameters.action >>]
     jobs:
-
       - build_and_test:
           context: SonarCloud Crime
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,14 @@ _snyk_options: &snyk_options
   token-variable: SNYK_TOKEN
   additional-arguments: --policy-path=.snyk
 
+_gradle_cache_keys: &gradle_cache_keys
+  - v1-gradle-cache-{{ checksum "settings.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "build.gradle" }}-{{ checksum "crime-commons-spring-boot-starter-rest-client/build.gradle" }}-{{ checksum "crime-commons-classes/build.gradle" }}-{{ checksum "crime-commons-schemas/build.gradle" }}-{{ checksum "crime-commons-mod-schemas/build.gradle" }}
+  - v1-gradle-cache-{{ checksum "settings.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "build.gradle" }}-
+  - v1-gradle-cache-
+
+_gradle_cache_key: &gradle_cache_key
+  v1-gradle-cache-{{ checksum "settings.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "build.gradle" }}-{{ checksum "crime-commons-spring-boot-starter-rest-client/build.gradle" }}-{{ checksum "crime-commons-classes/build.gradle" }}-{{ checksum "crime-commons-schemas/build.gradle" }}-{{ checksum "crime-commons-mod-schemas/build.gradle" }}
+
 executors:
   openjdk-executor:
     resource_class: medium
@@ -64,10 +72,7 @@ jobs:
             - v1-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
 
       - restore_cache:
-          keys:
-            - v1-gradle-cache-{{ checksum "settings.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "build.gradle" }}-{{ checksum "crime-commons-spring-boot-starter-rest-client/build.gradle" }}-{{ checksum "crime-commons-classes/build.gradle" }}-{{ checksum "crime-commons-schemas/build.gradle" }}-{{ checksum "crime-commons-mod-schemas/build.gradle" }}
-            - v1-gradle-cache-{{ checksum "settings.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "build.gradle" }}-
-            - v1-gradle-cache-
+          keys: *gradle_cache_keys
 
       - run:
           name: Build and test all modules
@@ -91,7 +96,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.gradle/caches
-          key: v1-gradle-cache-{{ checksum "settings.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "build.gradle" }}-{{ checksum "crime-commons-spring-boot-starter-rest-client/build.gradle" }}-{{ checksum "crime-commons-classes/build.gradle" }}-{{ checksum "crime-commons-schemas/build.gradle" }}-{{ checksum "crime-commons-mod-schemas/build.gradle" }}
+          key: *gradle_cache_key
 
   snyk_scan:
     executor: openjdk-executor
@@ -120,10 +125,7 @@ jobs:
             - v1-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
 
       - restore_cache:
-          keys:
-            - v1-gradle-cache-{{ checksum "settings.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "build.gradle" }}-{{ checksum "crime-commons-spring-boot-starter-rest-client/build.gradle" }}-{{ checksum "crime-commons-classes/build.gradle" }}-{{ checksum "crime-commons-schemas/build.gradle" }}-{{ checksum "crime-commons-mod-schemas/build.gradle" }}
-            - v1-gradle-cache-{{ checksum "settings.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "build.gradle" }}-
-            - v1-gradle-cache-
+          keys: *gradle_cache_keys
 
       - run:
           name: Publish release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,22 @@ version: 2.1
 orbs:
   snyk: snyk/snyk@1.1.2
 
+parameters:
+  release_type:
+    type: enum
+    enum: ["none", "major", "minor", "patch", "snapshot"]
+    default: "none"
+
+  release_module:
+    type: enum
+    enum:
+      - "none"
+      - "crime-commons-spring-boot-starter-rest-client"
+      - "crime-commons-classes"
+      - "crime-commons-schemas"
+      - "crime-commons-mod-schemas"
+    default: "none"
+
 _snyk_options: &snyk_options
   project: "${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BRANCH}"
   organization: "legal-aid-agency"
@@ -12,83 +28,44 @@ _snyk_options: &snyk_options
   token-variable: SNYK_TOKEN
   additional-arguments: --policy-path=.snyk
 
-# ------------------
-# EXECUTORS
-# ------------------
 executors:
   openjdk-executor:
     resource_class: medium
     docker:
       - image: cimg/openjdk:21.0.6
 
-# ------------------
-# COMMANDS
-# ------------------
 commands:
-  publish_artefact:
-    description: >
-      Publish artefact to Maven Central
-    parameters:
-      type:
-        type: enum
-        default: "minor"
-        enum: ["minor", "major", "patch", "snapshot"]
-        description: Specifies the type of release (major, minor, patch, snapshot)
-      tagPrefix:
-        default: "rest-client-"
-        type: string
-        description: Tag prefix for semver plugin
-      module:
-        default: "crime-commons-spring-boot-starter-rest-client"
-        type: string
-        description: Module name for release and publish
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - v1-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
-            - v1-gradle-cache-{{ checksum "build.gradle" }}
-      - when:
-          condition:
-            equal: ["major", << parameters.type >>]
-          steps:
-            - run:
-                name: Publish major release to Maven Central
-                command: ./gradlew pushSemverTag "-PisSnapshot=false" "-Psemver.stage=final" "-Psemver.scope=major" "-Psemver.tagPrefix=<< parameters.tagPrefix >>" :<< parameters.module >>:publishToSonatype closeAndReleaseSonatypeStagingRepository
-      - when:
-          condition:
-            equal: ["minor", << parameters.type >>]
-          steps:
-            - run:
-                name: Publish minor release to Maven Central
-                command: ./gradlew pushSemverTag "-PisSnapshot=false" "-Psemver.stage=final" "-Psemver.scope=minor" "-Psemver.tagPrefix=<< parameters.tagPrefix >>" :<< parameters.module >>:publishToSonatype closeAndReleaseSonatypeStagingRepository
-
-      - when:
-          condition:
-            equal: ["patch", << parameters.type >>]
-          steps:
-            - run:
-                name: Publish patch release to Maven Central
-                command: ./gradlew pushSemverTag "-PisSnapshot=false" "-Psemver.stage=final" "-Psemver.scope=patch" "-Psemver.tagPrefix=<< parameters.tagPrefix >>" :<< parameters.module >>:publishToSonatype closeAndReleaseSonatypeStagingRepository
-
-      - when:
-          condition:
-            equal: ["snapshot", << parameters.type >>]
-          steps:
-            - run:
-                name: Publish snapshot release to Maven Central
-                command: ./gradlew pushSemverTag "-PisSnapshot=true" "-Psemver.stage=snapshot" "-Psemver.scope=minor" "-Psemver.tagPrefix=<< parameters.tagPrefix >>" :<< parameters.module >>:publishToSonatype closeAndReleaseSonatypeStagingRepository
-
   authenticate_host:
     description: >
       Add github.com to known hosts
     steps:
       - run: ssh-keyscan github.com >> ~/.ssh/known_hosts
 
-# ------------------
-# JOBS
-# ------------------
 jobs:
+  validate_release_parameters:
+    executor: openjdk-executor
+    steps:
+      - run:
+          name: Validate release parameters
+          command: |
+            RELEASE_TYPE="<< pipeline.parameters.release_type >>"
+            RELEASE_MODULE="<< pipeline.parameters.release_module >>"
+
+            if [ "$RELEASE_TYPE" = "none" ] || [ "$RELEASE_MODULE" = "none" ]; then
+              echo "Both release_type and release_module must be set for a release."
+              exit 1
+            fi
+
+            if [ "$RELEASE_TYPE" = "snapshot" ] && [ "$CIRCLE_BRANCH" = "main" ]; then
+              echo "Snapshot releases must not be run from main."
+              exit 1
+            fi
+
+            if [ "$RELEASE_TYPE" != "snapshot" ] && [ "$CIRCLE_BRANCH" != "main" ]; then
+              echo "Major/minor/patch releases must only be run from main."
+              exit 1
+            fi
+
   build_and_test:
     environment:
       _JAVA_OPTIONS: "-Xmx3g"
@@ -98,8 +75,7 @@ jobs:
     steps:
       - checkout:
           method: full
-      - attach_workspace:
-          at: .
+
       - restore_cache:
           keys:
             - v1-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
@@ -107,41 +83,46 @@ jobs:
             - v1-gradle-cache-{{ checksum "crime-commons-classes/build.gradle" }}
             - v1-gradle-cache-{{ checksum "crime-commons-schemas/build.gradle" }}
             - v1-gradle-cache-{{ checksum "crime-commons-mod-schemas/build.gradle" }}
+
       - run:
-          name: Build crime-commons-spring-boot-starter-rest-client and run tests
-          command: ./gradlew shadowJar crime-commons-spring-boot-starter-rest-client:build
-      - run:
-          name: Build crime-commons-classes and run tests
-          command: ./gradlew crime-commons-classes:build
-      - run:
-          name: Build crime-commons-schemas and run tests
-          command: ./gradlew crime-commons-schemas:build
-      - run:
-          name: Build crime-commons-mod-schemas and run tests
-          command: ./gradlew crime-commons-mod-schemas:build
+          name: Build and test all modules
+          command: |
+            ./gradlew \
+              shadowJar \
+              crime-commons-spring-boot-starter-rest-client:build \
+              crime-commons-classes:build \
+              crime-commons-schemas:build \
+              crime-commons-mod-schemas:build
+
       - run:
           name: Run SonarQube
           command: ./gradlew sonar
+
       - save_cache:
           paths:
             - ~/.gradle/wrapper
           key: v1-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+
       - save_cache:
           paths:
             - ~/.gradle/caches
           key: v1-gradle-cache-{{ checksum "crime-commons-spring-boot-starter-rest-client/build.gradle" }}
+
       - save_cache:
           paths:
             - ~/.gradle/caches
           key: v1-gradle-cache-{{ checksum "crime-commons-classes/build.gradle" }}
+
       - save_cache:
           paths:
             - ~/.gradle/caches
           key: v1-gradle-cache-{{ checksum "crime-commons-schemas/build.gradle" }}
+
       - save_cache:
           paths:
             - ~/.gradle/caches
           key: v1-gradle-cache-{{ checksum "crime-commons-mod-schemas/build.gradle" }}
+
       - persist_to_workspace:
           root: .
           paths:
@@ -157,363 +138,106 @@ jobs:
           <<: *snyk_options
 
   publish_release:
-    parameters:
-      release_type:
-        type: enum
-        enum: ["minor", "major", "patch", "snapshot"]
-        description: Specifies the type of release (major, minor, patch, snapshot)
-      module:
-        type: string
-        description: Module name for release and publish
-      tagPrefix:
-        type: string
-        description: Tag prefix for semver plugin
     executor: openjdk-executor
-    working_directory: ~/laa-crime-commons/<< parameters.module >>
+    working_directory: ~/laa-crime-commons
     steps:
       - add_ssh_keys:
           fingerprints:
             - "6b:a8:8f:5d:a4:fc:7e:03:b2:0f:e2:a5:0a:ae:8f:8b"
-      - authenticate_host
-      - publish_artefact:
-          type: << parameters.release_type >>
-          module: << parameters.module >>
-          tagPrefix: << parameters.tagPrefix >>
 
-# ------------------
-# WORKFLOWS
-# ------------------
+      - authenticate_host
+
+      - checkout:
+          method: full
+
+      - restore_cache:
+          keys:
+            - v1-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+            - v1-gradle-cache-{{ checksum "build.gradle" }}
+
+      - run:
+          name: Publish release
+          command: |
+            RELEASE_TYPE="<< pipeline.parameters.release_type >>"
+            MODULE="<< pipeline.parameters.release_module >>"
+
+            case "$MODULE" in
+              "crime-commons-spring-boot-starter-rest-client")
+                TAG_PREFIX="rest-client-"
+                ;;
+              "crime-commons-classes")
+                TAG_PREFIX="crime-commons-classes-"
+                ;;
+              "crime-commons-schemas")
+                TAG_PREFIX="crime-commons-schemas-"
+                ;;
+              "crime-commons-mod-schemas")
+                TAG_PREFIX="crime-commons-mod-schemas-"
+                ;;
+              *)
+                echo "Unknown module: $MODULE"
+                exit 1
+                ;;
+            esac
+
+            if [ "$RELEASE_TYPE" = "snapshot" ]; then
+              ./gradlew pushSemverTag \
+                "-PisSnapshot=true" \
+                "-Psemver.stage=snapshot" \
+                "-Psemver.scope=minor" \
+                "-Psemver.tagPrefix=$TAG_PREFIX" \
+                ":$MODULE:publishToSonatype" \
+                closeAndReleaseSonatypeStagingRepository
+            else
+              ./gradlew pushSemverTag \
+                "-PisSnapshot=false" \
+                "-Psemver.stage=final" \
+                "-Psemver.scope=$RELEASE_TYPE" \
+                "-Psemver.tagPrefix=$TAG_PREFIX" \
+                ":$MODULE:publishToSonatype" \
+                closeAndReleaseSonatypeStagingRepository
+            fi
+
 workflows:
   version: 2
 
-  build_publish_main_rest_client:
+  build:
+    when:
+      and:
+        - equal: ["none", << pipeline.parameters.release_type >>]
+        - equal: ["none", << pipeline.parameters.release_module >>]
     jobs:
       - build_and_test:
-          filters:
-            branches:
-              only:
-                - main
           context: SonarCloud Crime
 
       - snyk_scan:
           requires:
             - build_and_test
 
-      - major_release_approval:
-          type: approval
-          requires:
-            - snyk_scan
-
-      - publish_release:
-          release_type: "major"
-          module: "crime-commons-spring-boot-starter-rest-client"
-          tagPrefix: "rest-client-"
-          requires:
-            - major_release_approval
-          name: "Publish major release: rest client"
-
-      - minor_release_approval:
-          type: approval
-          requires:
-            - snyk_scan
-
-      - publish_release:
-          release_type: "minor"
-          module: "crime-commons-spring-boot-starter-rest-client"
-          tagPrefix: "rest-client-"
-          requires:
-            - minor_release_approval
-          name: "Publish minor release: rest client"
-
-      - patch_release_approval:
-          type: approval
-          requires:
-            - snyk_scan
-
-      - publish_release:
-          release_type: "patch"
-          module: "crime-commons-spring-boot-starter-rest-client"
-          tagPrefix: "rest-client-"
-          requires:
-            - patch_release_approval
-          name: "Publish patch release: rest client"
-
-  build_publish_branch_rest_client:
+  release:
+    when:
+      or:
+        - not:
+            equal: ["none", << pipeline.parameters.release_type >>]
+        - not:
+            equal: ["none", << pipeline.parameters.release_module >>]
     jobs:
-      - branch_build_approval:
-          type: approval
-          filters:
-            branches:
-              ignore:
-                - main
+      - validate_release_parameters
 
       - build_and_test:
           requires:
-            - branch_build_approval
+            - validate_release_parameters
           context: SonarCloud Crime
 
       - snyk_scan:
           requires:
             - build_and_test
 
-      - snapshot_release_approval:
+      - approve_release:
           type: approval
           requires:
             - snyk_scan
 
       - publish_release:
-          release_type: "snapshot"
-          module: "crime-commons-spring-boot-starter-rest-client"
-          tagPrefix: "rest-client-"
           requires:
-            - snapshot_release_approval
-          name: "Publish snapshot release: rest client"
-
-  build_publish_main_crime_commons_classes:
-    jobs:
-      - build_and_test:
-          filters:
-            branches:
-              only:
-                - main
-          context: SonarCloud Crime
-
-      - snyk_scan:
-          requires:
-            - build_and_test
-
-      - major_release_approval:
-          type: approval
-          requires:
-            - snyk_scan
-
-      - publish_release:
-          release_type: "major"
-          module: "crime-commons-classes"
-          tagPrefix: "crime-commons-classes-"
-          requires:
-            - major_release_approval
-          name: "Publish major release: commons classes"
-
-      - minor_release_approval:
-          type: approval
-          requires:
-            - snyk_scan
-
-      - publish_release:
-          release_type: "minor"
-          module: "crime-commons-classes"
-          tagPrefix: "crime-commons-classes-"
-          requires:
-            - minor_release_approval
-          name: "Publish minor release: commons classes"
-
-      - patch_release_approval:
-          type: approval
-          requires:
-            - snyk_scan
-
-      - publish_release:
-          release_type: "patch"
-          module: "crime-commons-classes"
-          tagPrefix: "crime-commons-classes-"
-          requires:
-            - patch_release_approval
-          name: "Publish patch release: commons classes"
-
-  build_publish_branch_crime_commons_classes:
-    jobs:
-      - branch_build_approval:
-          type: approval
-          filters:
-            branches:
-              ignore:
-                - main
-
-      - build_and_test:
-          requires:
-            - branch_build_approval
-          context: SonarCloud Crime
-
-      - snyk_scan:
-          requires:
-            - build_and_test
-
-      - snapshot_release_approval:
-          type: approval
-          requires:
-            - snyk_scan
-
-      - publish_release:
-          release_type: "snapshot"
-          module: "crime-commons-classes"
-          tagPrefix: "crime-commons-classes-"
-          requires:
-            - snapshot_release_approval
-          name: "Publish snapshot release: commons classes"
-
-  build_publish_main_crime_commons_schemas:
-    jobs:
-      - build_and_test:
-          filters:
-            branches:
-              only:
-                - main
-          context: SonarCloud Crime
-
-      - snyk_scan:
-          requires:
-            - build_and_test
-
-      - major_release_approval:
-          type: approval
-          requires:
-            - snyk_scan
-
-      - publish_release:
-          release_type: "major"
-          module: "crime-commons-schemas"
-          tagPrefix: "crime-commons-schemas-"
-          requires:
-            - major_release_approval
-          name: "Publish major release: commons schemas"
-
-      - minor_release_approval:
-          type: approval
-          requires:
-            - snyk_scan
-
-      - publish_release:
-          release_type: "minor"
-          module: "crime-commons-schemas"
-          tagPrefix: "crime-commons-schemas-"
-          requires:
-            - minor_release_approval
-          name: "Publish minor release: commons schemas"
-
-      - patch_release_approval:
-          type: approval
-          requires:
-            - snyk_scan
-
-      - publish_release:
-          release_type: "patch"
-          module: "crime-commons-schemas"
-          tagPrefix: "crime-commons-schemas-"
-          requires:
-            - patch_release_approval
-          name: "Publish patch release: commons schemas"
-
-  build_publish_branch_crime_commons_schemas:
-    jobs:
-      - branch_build_approval:
-          type: approval
-          filters:
-            branches:
-              ignore:
-                - main
-
-      - build_and_test:
-          requires:
-            - branch_build_approval
-          context: SonarCloud Crime
-
-      - snyk_scan:
-          requires:
-            - build_and_test
-
-      - snapshot_release_approval:
-          type: approval
-          requires:
-            - snyk_scan
-
-      - publish_release:
-          release_type: "snapshot"
-          module: "crime-commons-schemas"
-          tagPrefix: "crime-commons-schemas-"
-          requires:
-            - snapshot_release_approval
-          name: "Publish snapshot release: commons schemas"
-
-  build_publish_main_crime_commons_mod_schemas:
-    jobs:
-      - build_and_test:
-          filters:
-            branches:
-              only:
-                - main
-          context: SonarCloud Crime
-
-      - snyk_scan:
-          requires:
-            - build_and_test
-
-      - major_release_approval:
-          type: approval
-          requires:
-            - snyk_scan
-
-      - publish_release:
-          release_type: "major"
-          module: "crime-commons-mod-schemas"
-          tagPrefix: "crime-commons-mod-schemas-"
-          requires:
-            - major_release_approval
-          name: "Publish major release: commons mod schemas"
-
-      - minor_release_approval:
-          type: approval
-          requires:
-            - snyk_scan
-
-      - publish_release:
-          release_type: "minor"
-          module: "crime-commons-mod-schemas"
-          tagPrefix: "crime-commons-mod-schemas-"
-          requires:
-            - minor_release_approval
-          name: "Publish minor release: commons mod schemas"
-
-      - patch_release_approval:
-          type: approval
-          requires:
-            - snyk_scan
-
-      - publish_release:
-          release_type: "patch"
-          module: "crime-commons-mod-schemas"
-          tagPrefix: "crime-commons-mod-schemas-"
-          requires:
-            - patch_release_approval
-          name: "Publish patch release: commons mod schemas"
-
-  build_publish_branch_crime_commons_mod-schemas:
-    jobs:
-      - branch_build_approval:
-          type: approval
-          filters:
-            branches:
-              ignore:
-                - main
-
-      - build_and_test:
-          requires:
-            - branch_build_approval
-          context: SonarCloud Crime
-
-      - snyk_scan:
-          requires:
-            - build_and_test
-
-      - snapshot_release_approval:
-          type: approval
-          requires:
-            - snyk_scan
-
-      - publish_release:
-          release_type: "snapshot"
-          module: "crime-commons-mod-schemas"
-          tagPrefix: "crime-commons-mod-schemas-"
-          requires:
-            - snapshot_release_approval
-          name: "Publish snapshot release: commons mod schemas"
+            - approve_release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,13 @@ orbs:
 parameters:
   action:
     type: enum
-    enum: [ "build", "release" ]
+    enum: ["build", "release"]
     default: "build"
     description: "The action to perform"
 
   release_type:
     type: enum
-    enum: [ "major", "minor", "patch", "snapshot" ]
+    enum: ["major", "minor", "patch", "snapshot"]
     default: "patch"
     description: "The type of release to perform"
 
@@ -176,7 +176,7 @@ workflows:
 
   build:
     when:
-      equal: [ "build", << pipeline.parameters.action >> ]
+      equal: ["build", << pipeline.parameters.action >>]
     jobs:
       - build_and_test:
           context: SonarCloud Crime
@@ -187,7 +187,7 @@ workflows:
 
   release:
     when:
-      equal: [ "release", << pipeline.parameters.action >> ]
+      equal: ["release", << pipeline.parameters.action >>]
     jobs:
       - build_and_test:
           context: SonarCloud Crime

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,47 @@ commands:
       - run: ssh-keyscan github.com >> ~/.ssh/known_hosts
 
 jobs:
-  builds,
+  build_and_test:
+    environment:
+      _JAVA_OPTIONS: "-Xmx3g"
+      GRADLE_OPTS: "-Dorg.gradle.daemon=t --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED"
+    executor: openjdk-executor
+    working_directory: ~/laa-crime-commons
+    steps:
+      - checkout:
+          method: full
+
+      - restore_cache:
+          keys:
+            - v1-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+
+      - restore_cache:
+          keys:
+            - v1-gradle-cache-{{ checksum "settings.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "build.gradle" }}-{{ checksum "crime-commons-spring-boot-starter-rest-client/build.gradle" }}-{{ checksum "crime-commons-classes/build.gradle" }}-{{ checksum "crime-commons-schemas/build.gradle" }}-{{ checksum "crime-commons-mod-schemas/build.gradle" }}
+
+      - run:
+          name: Build and test all modules
+          command: |
+            ./gradlew \
+              crime-commons-spring-boot-starter-rest-client:shadowJar \
+              crime-commons-spring-boot-starter-rest-client:build \
+              crime-commons-classes:build \
+              crime-commons-schemas:build \
+              crime-commons-mod-schemas:build
+
+      - run:
+          name: Run SonarQube
+          command: ./gradlew sonar
+
+      - save_cache:
+          paths:
+            - ~/.gradle/wrapper
+          key: v1-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+
+      - save_cache:
+          paths:
+            - ~/.gradle/caches
+          key: v1-gradle-cache-{{ checksum "settings.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "build.gradle" }}-{{ checksum "crime-commons-spring-boot-starter-rest-client/build.gradle" }}-{{ checksum "crime-commons-classes/build.gradle" }}-{{ checksum "crime-commons-schemas/build.gradle" }}-{{ checksum "crime-commons-mod-schemas/build.gradle" }}
 
   snyk_scan:
     executor: openjdk-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,39 +134,18 @@ jobs:
               exit 1
             fi
 
-            case "$MODULE" in
-              "crime-commons-spring-boot-starter-rest-client")
-                TAG_PREFIX="rest-client-"
-                ;;
-              "crime-commons-classes")
-                TAG_PREFIX="crime-commons-classes-"
-                ;;
-              "crime-commons-schemas")
-                TAG_PREFIX="crime-commons-schemas-"
-                ;;
-              "crime-commons-mod-schemas")
-                TAG_PREFIX="crime-commons-mod-schemas-"
-                ;;
-              *)
-                echo "Unknown module: $MODULE"
-                exit 1
-                ;;
-            esac
-
             if [ "$RELEASE_TYPE" = "snapshot" ]; then
-              ./gradlew pushSemverTag \
+              ./gradlew ":$MODULE:pushSemverTag" \
                 "-PisSnapshot=true" \
                 "-Psemver.stage=snapshot" \
                 "-Psemver.scope=minor" \
-                "-Psemver.tagPrefix=$TAG_PREFIX" \
                 ":$MODULE:publishToSonatype" \
                 closeAndReleaseSonatypeStagingRepository
             else
-              ./gradlew pushSemverTag \
+              ./gradlew ":$MODULE:pushSemverTag" \
                 "-PisSnapshot=false" \
                 "-Psemver.stage=final" \
                 "-Psemver.scope=$RELEASE_TYPE" \
-                "-Psemver.tagPrefix=$TAG_PREFIX" \
                 ":$MODULE:publishToSonatype" \
                 closeAndReleaseSonatypeStagingRepository
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,13 @@ orbs:
 parameters:
   action:
     type: enum
-    enum: ["build", "release"]
+    enum: [ "build", "release" ]
     default: "build"
     description: "The action to perform"
 
   release_type:
     type: enum
-    enum: ["major", "minor", "patch", "snapshot"]
+    enum: [ "major", "minor", "patch", "snapshot" ]
     default: "patch"
     description: "The type of release to perform"
 
@@ -49,62 +49,7 @@ commands:
       - run: ssh-keyscan github.com >> ~/.ssh/known_hosts
 
 jobs:
-  build_and_test:
-    environment:
-      _JAVA_OPTIONS: "-Xmx3g"
-      GRADLE_OPTS: "-Dorg.gradle.daemon=t --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED"
-    executor: openjdk-executor
-    working_directory: ~/laa-crime-commons
-    steps:
-      - checkout:
-          method: full
-
-      - restore_cache:
-          keys:
-            - v1-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
-            - v1-gradle-cache-{{ checksum "crime-commons-spring-boot-starter-rest-client/build.gradle" }}
-            - v1-gradle-cache-{{ checksum "crime-commons-classes/build.gradle" }}
-            - v1-gradle-cache-{{ checksum "crime-commons-schemas/build.gradle" }}
-            - v1-gradle-cache-{{ checksum "crime-commons-mod-schemas/build.gradle" }}
-
-      - run:
-          name: Build and test all modules
-          command: |
-            ./gradlew \
-              shadowJar \
-              crime-commons-spring-boot-starter-rest-client:build \
-              crime-commons-classes:build \
-              crime-commons-schemas:build \
-              crime-commons-mod-schemas:build
-
-      - run:
-          name: Run SonarQube
-          command: ./gradlew sonar
-
-      - save_cache:
-          paths:
-            - ~/.gradle/wrapper
-          key: v1-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
-
-      - save_cache:
-          paths:
-            - ~/.gradle/caches
-          key: v1-gradle-cache-{{ checksum "crime-commons-spring-boot-starter-rest-client/build.gradle" }}
-
-      - save_cache:
-          paths:
-            - ~/.gradle/caches
-          key: v1-gradle-cache-{{ checksum "crime-commons-classes/build.gradle" }}
-
-      - save_cache:
-          paths:
-            - ~/.gradle/caches
-          key: v1-gradle-cache-{{ checksum "crime-commons-schemas/build.gradle" }}
-
-      - save_cache:
-          paths:
-            - ~/.gradle/caches
-          key: v1-gradle-cache-{{ checksum "crime-commons-mod-schemas/build.gradle" }}
+  builds,
 
   snyk_scan:
     executor: openjdk-executor
@@ -191,7 +136,7 @@ workflows:
 
   build:
     when:
-      equal: ["build", << pipeline.parameters.action >>]
+      equal: [ "build", << pipeline.parameters.action >> ]
     jobs:
       - build_and_test:
           context: SonarCloud Crime
@@ -202,7 +147,7 @@ workflows:
 
   release:
     when:
-      equal: ["release", << pipeline.parameters.action >>]
+      equal: [ "release", << pipeline.parameters.action >> ]
     jobs:
       - build_and_test:
           context: SonarCloud Crime

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,7 @@ _gradle_cache_keys: &gradle_cache_keys
   - v1-gradle-cache-{{ checksum "settings.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "build.gradle" }}-
   - v1-gradle-cache-
 
-_gradle_cache_key: &gradle_cache_key
-  v1-gradle-cache-{{ checksum "settings.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "build.gradle" }}-{{ checksum "crime-commons-spring-boot-starter-rest-client/build.gradle" }}-{{ checksum "crime-commons-classes/build.gradle" }}-{{ checksum "crime-commons-schemas/build.gradle" }}-{{ checksum "crime-commons-mod-schemas/build.gradle" }}
+_gradle_cache_key: &gradle_cache_key v1-gradle-cache-{{ checksum "settings.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "build.gradle" }}-{{ checksum "crime-commons-spring-boot-starter-rest-client/build.gradle" }}-{{ checksum "crime-commons-classes/build.gradle" }}-{{ checksum "crime-commons-schemas/build.gradle" }}-{{ checksum "crime-commons-mod-schemas/build.gradle" }}
 
 executors:
   openjdk-executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,11 +106,6 @@ jobs:
             - ~/.gradle/caches
           key: v1-gradle-cache-{{ checksum "crime-commons-mod-schemas/build.gradle" }}
 
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .
-
   snyk_scan:
     executor: openjdk-executor
     working_directory: ~/laa-crime-commons


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1888)

# Summary

This PR refactors the CircleCI release workflow.

Previously, each module had its own independent build/release workflow, which resulted in the project being repeatedly built and tested multiple times per pipeline execution. This worked, but introduced significant duplication, unnecessary pipeline runtime and an increasingly noisy workflow UI with the addition of more modules.

This change consolidates the build/test execution into a single shared pipeline and moves releases to a parameterised manual workflow model.

# What Changed

## Consolidated build/test execution

The project is now built and tested once per pipeline execution rather than once per module workflow.

This significantly reduces duplicated CI work and pipeline runtime.

## Introduced manual parameterised releases

Releases are now triggered manually using CircleCI pipeline parameters rather than exposing every module/release type combination as separate approval and publish jobs.

The release workflow now accepts:
- `release_type`
  - `major`
  - `minor`
  - `patch`
  - `snapshot`
- `release_module`
  - `crime-commons-spring-boot-starter-rest-client`
  - `crime-commons-classes`
  - `crime-commons-schemas`
  - `crime-commons-mod-schemas`

## Simplified Workflow Structure

The workflow model is now split into:
- Standard CI pipelines for normal pushes
- Explicit release pipelines for publishing artefacts

This removes the large matrix of approval/release jobs from the workflow UI and PR checks view.

## Added Release Validation

The release job now validates:
- snapshot releases cannot be run from main
- major/minor/patch releases can only be run from main

# Benefits

- Significantly reduced duplicated CI execution
- Cleaner CircleCI workflow UI
- Cleaner GitHub PR checks
- Releases become explicit operator actions
- Constrained release inputs reduce the potential for errors
- Simpler and more maintainable workflow configuration
- Easier future migration path to GitHub Actions (`workflow_dispatch`)
- Aligns more closely with the existing functional test workflow model

# Running a Release

1. Trigger a new pipeline manually in CircleCI
2. Set:
   - action=`release`
   - release_type=`<type>`
   - release_module=`<module>`
3. Approve the release job when prompted
