### PR TITLE
LCAM-2100 - Fix incorrect semver generation in crime-commons release pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,7 @@ jobs:
           name: Build and test all modules
           command: |
             ./gradlew \
+              -x printSemver \
               crime-commons-spring-boot-starter-rest-client:shadowJar \
               crime-commons-spring-boot-starter-rest-client:build \
               crime-commons-classes:build \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,12 +141,21 @@ jobs:
               echo "Major/minor/patch releases must only be run from main."
               exit 1
             fi
+            
+            TAG_PREFIX="$MODULE-"
+            
+            case "$MODULE" in
+              "crime-commons-spring-boot-starter-rest-client")
+                TAG_PREFIX="rest-client-"
+                ;;
+            esac
 
             if [ "$RELEASE_TYPE" = "snapshot" ]; then
               ./gradlew ":$MODULE:pushSemverTag" \
                 "-PisSnapshot=true" \
                 "-Psemver.stage=snapshot" \
                 "-Psemver.scope=minor" \
+                "-Psemver.tagPrefix=$TAG_PREFIX" \
                 ":$MODULE:publishToSonatype" \
                 closeAndReleaseSonatypeStagingRepository
             else
@@ -154,6 +163,7 @@ jobs:
                 "-PisSnapshot=false" \
                 "-Psemver.stage=final" \
                 "-Psemver.scope=$RELEASE_TYPE" \
+                "-Psemver.tagPrefix=$TAG_PREFIX" \
                 ":$MODULE:publishToSonatype" \
                 closeAndReleaseSonatypeStagingRepository
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,9 +141,9 @@ jobs:
               echo "Major/minor/patch releases must only be run from main."
               exit 1
             fi
-            
+
             TAG_PREFIX="$MODULE-"
-            
+
             case "$MODULE" in
               "crime-commons-spring-boot-starter-rest-client")
                 TAG_PREFIX="rest-client-"


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-2100)

## Background

The crime-commons release pipeline was generating incorrect semantic versions following recent changes.

Instead of incrementing the expected semantic version, the semver plugin was producing commit-distance versions such as:

`4.38.0.17+6a8e424`

This was caused by the CI pipeline not explicitly passing the `semver.tagPrefix` property when invoking release tasks. As a result, the plugin was unable to resolve the correct tag stream for version calculation.

Additionally, the `printSemver` task was being executed during the initial build/test phase where it was not required.

## Changes

- Updated the release pipeline to explicitly pass `-Psemver.tagPrefix`
- Added handling for the rest-client module, whose tag prefix does not match the module name
- Prevented `printSemver` from running during the initial build/test step
- Verified snapshot and final release version generation behaves as expected

## Result

Release pipelines now generate the expected semantic versions and no longer produce commit-distance versions during releases.

The initial build/test phase is also slightly cleaner and avoids unnecessary semver task execution.

## Checklists

In general these checks apply to most PRs. There will be exceptions, in these cases make it clear what is different and why.
e.g. DRAFT PR because you want early feedback, change only warrants a more targeted run of functional tests, etc.

Some checks can be completed after asking for review, but should be done before merging. Consider what checks will make a reviewers job easier.

### Git housekeeping
- [x] The pull request is not labelled as `WIP/DRAFT`.
- [x] The pull request has a title format of `{JIRA ID} - Description`.
- [x] A link to the Jira ticket is provided along with a description giving context and rationale for the changes, in the `What` section of the PR.
- [x] GitHub is not reporting any conflicts with the `main` branch.
- [x] Nothing unexpected is included in the changes, when compared to the `main` branch.
- [x] All of the pull request triggered checks (such as Build and Test, CodeQL and Snyk) have passed.
- [x] The commit messages have meaningful descriptions.
- [x] If changes include UI modifications, include before and after screenshots to aid reviewers.

### Change housekeeping
- [ ] Relevant areas in the documentation have been updated to reflect the changes. This may include runbooks, alerts, confluence, etc.
- [ ] Attach link / screenshot from successful CI run of UI `@smoke` tests for this branch using [ExecuteUiTests workflow][1].
- [ ] Attach link / screenshot from successful CI run of **ALL** API tests for this branch using [ExecuteApiTests workflow][2].

[1]: https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml
[2]: https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteApiTests.yaml
